### PR TITLE
[Fix] Remove editor-sdk references

### DIFF
--- a/contribution.md
+++ b/contribution.md
@@ -11,7 +11,7 @@ Please note that this project is released with a Contributor Code of Conduct. By
 2. Create a new branch: `git checkout -b my-branch-name` \*
 3. Make sure your changes pass a spell check (US English)
 4. Build the project locally and run local tests
-5. Push to your fork and [submit a pull request](https://github.com/chili-publish/editor-sdk/compare)
+5. Push to your fork and [submit a pull request](https://github.com/chili-publish/grafx-documentation/compare)
 6. Pat yourself on the back and wait for your pull request to be reviewed and get merged
 
 **my-branch-name**: We use the prefixes **fix**, **feature**, **solution** in our branches to indicate what they represent. 

--- a/docs/GraFx-Studio/integration/getting-started/index.md
+++ b/docs/GraFx-Studio/integration/getting-started/index.md
@@ -47,7 +47,7 @@ You can use this script in your HTML to always get the latest SDK version:
 Or you can use NPM to install a specific SDK version, with the following command:
 
 ``` bash
-npm install @chili-publish/editor-sdk
+npm install @chili-publish/studio-sdk
 ```
 
 #### stateChanged event will be deprecated

--- a/docs/release-notes/2022.md
+++ b/docs/release-notes/2022.md
@@ -2,7 +2,7 @@
 
 ## Dec 23, 2022 - GraFx Studio
 
-Version 0.97.1, using Studio SDK [0.97.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.97.1, using Studio SDK [0.97.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ### Improvements
 
@@ -16,7 +16,7 @@ Version 0.97.1, using Studio SDK [0.97.0](https://github.com/chili-publish/edito
 
 ## Dec 16, 2022 - GraFx Studio
 
-Version 0.95.1, using Studio SDK [0.95.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.95.1, using Studio SDK [0.95.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ### Features
 
@@ -45,7 +45,7 @@ Version 0.95.1, using Studio SDK [0.95.0](https://github.com/chili-publish/edito
 
 ## Nov 18, 2022 - GraFx Studio
 
-Version 0.88.3, using Studio SDK [0.88.2](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.88.3, using Studio SDK [0.88.2](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ### Features
 
@@ -79,7 +79,7 @@ Version 0.88.3, using Studio SDK [0.88.2](https://github.com/chili-publish/edito
 
 ## Oct 12, 2022 - GraFx Studio
 
-Version 0.70.3, using Studio SDK [0.70.3](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.70.3, using Studio SDK [0.70.3](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ### Features
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -58,7 +58,7 @@ Read more about [User Management](https://docs.chiligrafx.com/CHILI_GraFx/user_m
 
 ## Apr 14, 2023 - GraFx Studio
 
-Version 0.117.1, using Studio SDK [0.117.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.117.1, using Studio SDK [0.117.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ![rn_icon](https://chilipublishdocs.imgix.net/logos/CHILI_LOGOS_OK-09.svg)
 
@@ -79,9 +79,9 @@ Version 0.117.1, using Studio SDK [0.117.0](https://github.com/chili-publish/edi
 	
 	There is a minor breaking change in the Studio SDK's typings.
 	It basically boils down to changing the import for the Id type, you can do it as follows:<br>
-	Change `#!typescript import { Id } from '@chili-publish/editor-sdk/lib/types/CommonTypes'`<br>
-	To `#!typescript import { Id } from '@chili-publish/editor-sdk'`<br>
-	For more information, please check out the [SDK release notes](https://github.com/chili-publish/editor-sdk/releases/tag/0.117.0){target="_blank"}.
+	Change `#!typescript import { Id } from '@chili-publish/studio-sdk/lib/types/CommonTypes'`<br>
+	To `#!typescript import { Id } from '@chili-publish/studio-sdk'`<br>
+	For more information, please check out the [SDK release notes](https://github.com/chili-publish/studio-sdk/releases/tag/0.117.0){target="_blank"}.
 
 ## Mar 31, 2023 - Infrastructure update
 
@@ -96,7 +96,7 @@ The update will be implemented (starting April 5) gradually on all tenants, and 
 
 ## Mar 29, 2023 - GraFx Studio
 
-Version 0.116.2, using Studio SDK [0.116.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.116.2, using Studio SDK [0.116.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ![rn_icon](https://chilipublishdocs.imgix.net/logos/CHILI_LOGOS_OK-09.svg)
 
@@ -137,7 +137,7 @@ With this update, we’re implementing a new platform infrastructure that greatl
 
 ## Mar 16, 2023 - GraFx Studio
 
-Version 0.114.1, using Studio SDK [0.114.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.114.1, using Studio SDK [0.114.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ![rn_icon](https://chilipublishdocs.imgix.net/logos/CHILI_LOGOS_OK-09.svg)
 
@@ -174,7 +174,7 @@ Version 0.114.1, using Studio SDK [0.114.0](https://github.com/chili-publish/edi
 
 ## Mar 1, 2023 - GraFx Studio
 
-Version 0.111.2, using Studio SDK [0.111.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.111.2, using Studio SDK [0.111.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ### Features
 
@@ -199,7 +199,7 @@ Version 0.111.2, using Studio SDK [0.111.0](https://github.com/chili-publish/edi
 
 ## Feb 16, 2023 - GraFx Studio
 
-Version 0.107.4, using Studio SDK [0.107.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.107.4, using Studio SDK [0.107.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ### Features
 
@@ -233,7 +233,7 @@ Version 0.107.4, using Studio SDK [0.107.0](https://github.com/chili-publish/edi
 
 ## Jan 30, 2023 - GraFx Studio
 
-Version 0.104.1, using Studio SDK [0.104.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.104.1, using Studio SDK [0.104.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ### Fixes
 
@@ -246,7 +246,7 @@ Version 0.104.1, using Studio SDK [0.104.0](https://github.com/chili-publish/edi
 
 ## Jan 23, 2023 - GraFx Studio
 
-Version 0.102.2, using Studio SDK [0.102.0](https://github.com/chili-publish/editor-sdk/releases){target="_blank"}
+Version 0.102.2, using Studio SDK [0.102.0](https://github.com/chili-publish/studio-sdk/releases){target="_blank"}
 
 ### Features
 


### PR DESCRIPTION
This PR removes all editor-sdk references and renames them to studio-sdk