### PR TITLE
Add cURL example back to integration docs

### DIFF
--- a/docs/CHILI-GraFx/guides/integrations/index.md
+++ b/docs/CHILI-GraFx/guides/integrations/index.md
@@ -69,7 +69,7 @@ To get an access token we simply make a POST request to our auth server located 
 Here are some examples for making this request
 
 
-<!-- === "cURL"
+=== "cURL"
     ``` SH
     curl --location \
     --request POST 'https://integration-login.chiligrafx.com/oauth/token' \
@@ -79,7 +79,6 @@ Here are some examples for making this request
     --data-urlencode 'client_id=<CLIENT_ID>' \
     --data-urlencode 'client_secret=<CLIENT_SECRET>'
     ```
--->
 === "Python"
     ```python
     import requests


### PR DESCRIPTION
Added the cURL code example back to the integration docs, was temporarily removed due to an issue on the Auth API. This is now fixed so I am adding the example back.