### PR TITLE
FSSO - SAML - Add request email address domain

### DIFF
--- a/docs/CHILI-GraFx/concepts/federated-single-sign-on/saml/index.md
+++ b/docs/CHILI-GraFx/concepts/federated-single-sign-on/saml/index.md
@@ -10,7 +10,8 @@ This document lists the info for your SAML Identity Providers in the CGX Platfor
 	- Email 
 	- First Name 
 	- Last Name 
-- Identity attribute 
+- Identity attribute
+- Domain of the email addresses of your corporate users
 
 ## We will provide you
 


### PR DESCRIPTION
Added one element to request from the customer for SAML FSSO: the domain of the email addresses of the users of the customer.