### PR TITLE
GraFx Media - Improvements elements - normal version

### DIFF
--- a/docs/GraFx-Media/overview/elements/index.md
+++ b/docs/GraFx-Media/overview/elements/index.md
@@ -4,38 +4,31 @@ When opening GraFx Media, you see the action banner (1) and below all top level 
 
 ![appscreen](dashboard.png)
 
-### 1 Action banner
-
+**1 - Action Banner:**
 The area of the application where you interact with the contents. You can search, sort and change the view.
 
-### 2 Folders and media
-
+**2 - Folders and Media:**
 Similar to what you're used to in any OS, a view on the folders and their contents.
+
 
 ## Action banner
 
 ![appscreen](action-banner.png)
 
-### 3 Sort Field
-
+**3 - Sort Field:**
 Select the field you want to sort the contents below
 
-### 4 Sorting order
-
+**4 - Sorting order:**
 Select the order or sorting (ascending or descending)
 
-### 5 Search field
-
+**5 - Search field:**
 Search on the name or ID of an asset
 
-### 6 Create folder
-
+**6 - Create folder:**
 Add a (sub)folder at the current location
 
-### 7 Upload button
-
+**7 - Upload button:**
 Upload asset(s) to the current location. (You can upload 1 or more at the same time)
 
-### 8 View
-
+**8 - View:**
 View the contents in a grid or list view


### PR DESCRIPTION
The problem is that it is hard to read the page and reference the images. On my devices I get an experience like this:
![image](https://github.com/chili-publish/grafx-documentation/assets/49288508/add3aea8-733f-4975-8528-62f54f5f36c8)

Not fun 😔

There are 2 PRs to solve this problem: this awesome one or this other one: #219 - pick this one or the other.

By condensing the text and removing the headers, we break the table, but we make the information easy to consume in one look.
![image](https://github.com/chili-publish/grafx-documentation/assets/49288508/be6c9f2b-4d13-4256-aaab-e4bbfce8904c)