### PR TITLE
GraFx Fonts Simplify publisher msg

### DIFF
--- a/docs/GraFx-Fonts/concepts/fonts-in-publisher/index.md
+++ b/docs/GraFx-Fonts/concepts/fonts-in-publisher/index.md
@@ -1,26 +1,9 @@
 # Fonts in GraFx Publisher
 
-With the introduction of GraFx Fonts, a new way of working is introduced to handle fonts in GraFx Publisher and GraFx Studio.
-
-We've kept this separation to ensure that existing templates in GraFx Publisher continue to function as expected.
-
-## GraFx Publisher
-
 ![applogo](/assets/CHILI_publisher_RGB.svg)
 
+With the introduction of GraFx Fonts, a new way of working is introduced to handle fonts in GraFx Publisher and GraFx Studio. Fonts uploaded to the GraFx Fonts application are exclusively available for use in GraFx Studio. We've kept this separation to ensure that existing templates in GraFx Publisher continue to function as expected. 
 
-Single file fonts are used, not font families. To make these fonts available for use, you should upload them within the GraFx Publisher application.
-
-![fonts](fonts.png)
-
-## GraFx Studio
-
-![applogo](/assets/CHILI_LOGOS_OK-09.svg)
-
-A new approach is used, which supports font families. For fonts to work within this application, please upload them in the GraFx Fonts repository.
-
-![fonts](dashboard.png)
-
-It's important to note that fonts uploaded to the GraFx Fonts application are exclusively available for use in GraFx Studio. We've kept this separation to ensure that existing templates in GraFx Publisher continue to function as expected. 
+For information on how to work with fonts in GraFx Publisher, please see [CHILI publisher Fonts Documentation](https://chilipublishdocs.atlassian.net/wiki/spaces/CPDOC/pages/1413922/Fonts) for more information.
 
 Any fonts needed for GraFx Publisher templates should be uploaded within the GraFx Publisher application.


### PR DESCRIPTION
If someone gets to this page they just need to know: Fonts don't work with Publisher and how to get fonts into Publisher. This condensed format makes it clear and concise and removes the discussion of Studio, because this article is about Publisher not Studio.