### PR TITLE
add: release of Environment API 1.3.5

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,5 +1,13 @@
 # Release notes
 
+## ![rn_icon](https://chilipublishdocs.imgix.net/logos/CHILI_LOGOS_OK-04.svg) Jan 31, 2024 - CHILI GraFx
+
+CHILI GraFx [Environment API 1.3.5](/GraFx-Developers/#environment-api)
+
+### Improvements
+
+- New naming for default output settings
+
 ## ![rn_icon](/assets/CHILI_LOGOS_OK-21.svg) Jan 30, 2024 - GraFx Publisher
 
 ### Fixes
@@ -14,7 +22,6 @@
 - Fixed an error where you could not access the platform
 
 ## ![rn_icon](https://chilipublishdocs.imgix.net/logos/CHILI_LOGOS_OK-04.svg) Jan 25, 2024 - CHILI GraFx
-
 
 CHILI GraFx [Environment API 1.3.4](/GraFx-Developers/#environment-api)
 
@@ -59,8 +66,6 @@ api/v1/environment/{environmentId}/output/jpg
 - Improved performance when copying a file with an existing name
 
 ## ![rn_icon](https://chilipublishdocs.imgix.net/logos/CHILI_LOGOS_OK-04.svg) Jan 19, 2024 - CHILI GraFx
-
-
 
 ### Improvements
 


### PR DESCRIPTION
Release notes for [Environment API 1.3.5](https://chilipublishintranet.atlassian.net/wiki/spaces/CPDOC/pages/4832002049/Release+Approval+GraFx+Environment+API+1.3.5)
Mentioned only changed names for default output settings, small fix for user groups has been omitted, because it seems to be not relevant for clients, for now.