### PR TITLE
[Feat][WRS-2371] Generic documentation for data connectors

### DIFF
--- a/docs/GraFx-Developers/connectors/connectors-introduction/index.md
+++ b/docs/GraFx-Developers/connectors/connectors-introduction/index.md
@@ -38,22 +38,22 @@ The following types of services are particularly well-suited for Connector integ
 
 GraFx Studio currently supports two types of Connectors:
 
-1. **Media Connectors** (Experimental): 
+1. **Media Connectors** (Experimental):
 
    - Purpose: Import images into documents and update variables with metadata
    - Status: Currently available as an experimental feature
 
-2. **Data Connectors** (In Development):
+2. **Data Connectors** (Experimental):
 
    - Purpose: Import data to update document variables
-   - Status: Currently in development, expected release in 2025
+   - Status: Currently available as an experimental feature
 
 ## Getting Started
 
 If you're interested in building a Connector:
 
 - For Media Connectors, please refer to our [Media Connector Introduction](/GraFx-Developers/connectors/media-connector/media-connector-introduction/) guide for detailed instructions and best practices.
-- For Data Connectors, please check back in 2025 for updated information and documentation.
+- For Data Connectors, please refer to our [Data Connector Introduction](/GraFx-Developers/connectors/data-connector/data-connector-introduction/) guide for detailed instructions and best practices.
 
 ### Common Questions
 

--- a/docs/GraFx-Developers/connectors/data-connector/build-a-simple-data-connector/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/build-a-simple-data-connector/index.md
@@ -1,0 +1,228 @@
+# Build a Simple Data Connector
+
+This guide walks you through the process of creating a simple data connector using the Connector CLI tool. The connector will display mock user data from Mockaroo in the data selector of GraFx Studio Designer Workspace.
+
+## Requirements
+
+- Node.js or Bun.js
+- [Connector CLI](/GraFx-Developers/connectors/connector-cli/) tool
+- Environment Admin user with a Template Designer license applied
+- Mockaroo account (free tier available)
+
+## Prerequisites: Setting Up Mockaroo
+
+Before we begin, you'll need to set up a Mockaroo account, create a schema, and then create a custom API endpoint:
+
+1. Go to [Mockaroo](https://www.mockaroo.com/) and create a free account.
+2. Once logged in, navigate to the **Schemas** section.
+3. Click **Create New Schema** with following fields:
+
+    - `id` (Type: Row Number)
+    - `first_name` (Type: First Name)
+    - `last_name` (Type: Last Name)
+    - `email` (Type: Email Address)
+    - `gender` (Type: Gender)
+    - `ip_address` (Type: IP Address v4)
+
+4. Save the schema with a name, for example, **Users**.
+5. Next, navigate to the **APIs** section.
+6. Click **Create a new Mock API** to create a new API endpoint.
+7. Set the route (e.g., `/users.json`).
+8. In the Handler script, reference your saved schema and set the number of records to generate dynamically:
+
+       ```
+       schema "Users"
+       generate params['count']
+       ```
+
+    !!! note
+        Schema should match the name from step 4, **Users** for example
+
+9. Save the API. Note the full API URL, which will look like `https://my.api.mockaroo.com/users.json?key=YOUR_API_KEY`.
+10. Save your API key from the API settings page - you'll need it for the connector implementation.
+
+## Creating a New Connector Project
+
+1. Execute the command to create a new connector project:
+
+    ```bash
+    connector-cli new --type=data
+    ```
+
+    and follow the prompts to configure the project settings.
+
+2. Enter to the project directory:
+
+    ```bash
+    cd <projectName>
+    ```
+
+3. Install dependencies:
+
+    === "NPM"
+
+        ```bash
+        npm install
+        ```
+
+    === "Bun"
+
+        ```bash
+        bun install
+        ```
+
+4. Open `connector.ts` as this is the main connector file we will be modifying.
+
+## Modifying the getPage Method
+
+Our goal is to display mock user data from Mockaroo in the data selector. The `getPage` method is utilized by the default Studio GUIs to retrieve a list of data items for display.
+
+### Updating Capabilities
+
+First, we need to modify the `getCapabilities()` method to inform the UI about our connector's supported capabilities:
+
+```typescript
+getCapabilities(): Data.DataConnectorCapabilities {
+  return {
+    filtering: false,
+    sorting: false,
+    model: false,
+  };
+}
+```
+
+### Implementing the getPage Method
+
+Next, we'll modify the `getPage` method to perform the following tasks:
+
+1. Fetch a list of mock users from Mockaroo according to provided `limit` and `continuationToken`
+2. Transform the data to match the required format
+3. Return the data within the expected `DataPage` type
+
+We'll use the following endpoint to retrieve our mock data (replace `YOUR_API_KEY` with your actual key):
+
+```
+https://my.api.mockaroo.com/users.json?key=YOUR_API_KEY&count=${limit}
+```
+
+This endpoint returns `limit` number of mock users with the following structure:
+
+```typescript
+{
+  "id": number;
+  "first_name": string;
+  "last_name": string;
+  "email": string;
+  "gender": string;
+  "ip_address": string;
+}
+```
+
+Now, let's update our `getPage` method to handle this data and return the expected `DataPage` type:
+
+```typescript
+async getPage(
+  config: Data.PageConfig,
+  context: Connector.Dictionary
+): Promise<Data.DataPage> {
+  // We use the limit from config to determine how many items to fetch
+  const resp = await this.runtime.fetch(
+    `https://my.api.mockaroo.com/users.json?key=YOUR_API_KEY&count=${config.limit}`,
+    {
+      method: 'GET',
+    }
+  );
+
+  // Handle error case
+  if (!resp.ok) {
+    throw new ConnectorHttpError(
+      resp.status,
+      `[Mockaroo connector]: Failed to fetch data: ${resp.status}-${resp.statusText}`
+    );
+  }
+
+  const data = JSON.parse(resp.text);
+
+  // Transform the data to match our expected format
+  const dataFormatted = data.map((d) => ({
+    id: d.id.toString(),
+    firstName: d.first_name,
+    lastName: d.last_name,
+    email: d.email,
+    gender: d.gender,
+    ipAddress: d.ip_address
+  }));
+
+  return {
+    data: dataFormatted,
+    continuationToken: null // Mockaroo doesn't support pagination in free tier
+  };
+}
+```
+
+!!! warning "API Key Usage"
+    In this tutorial, we're using the API key directly in the code for simplicity. However, for production connectors, you should implement proper authorization following the [Authorization for Connectors](/GraFx-Developers/connectors/authorization-for-connectors/) documentation. This ensures secure handling of credentials and proper access control.
+
+## Publishing the Connector
+
+### Step 1: Logging In
+
+Before publishing your connector, you need to log in to CHILI GraFx. Run the following command and follow the on-screen instructions:
+
+```bash
+connector-cli login
+```
+
+### Step 2: Publishing
+
+After successfully logging in, you can publish your connector using the following command:
+
+```bash
+connector-cli publish \
+        -e <environment-name> \
+        -b <base-url> \
+        -n <name> \
+        --proxyOption.allowedDomains "my.api.mockaroo.com"
+```
+
+#### Command Arguments
+
+- `-e <environment-name>`: The environment where you want to deploy your connector.
+- `-b <base-url>`: The base URL for CHILI GraFx API. Use one of the following formats:
+    - **Production** Environments: `https://{environment-name}.chili-publish.online/grafx`
+    - **Sandbox** Environments: `https://{environment-name}.chili-publish-sandbox.online/grafx`
+- `-n <name>`: The name of your connector as it will appear in the GraFx Studio.
+- `--proxyOption.allowedDomains "my.api.mockaroo.com"`: Specifies allowed domains for all requests that we're making from the connector.
+
+### Step 3: Enabling the connector
+
+The connector published in the previous step is initially unavailable for use in GraFx Studio Designer Workspace. To activate it, access the connector's settings in the Platform for the desired environment and turn on the `Availability` switch next to the newly deployed connector.
+
+### Step 4: Verifying
+
+To verify that your connector has been available successfully:
+
+1. Open GraFx Studio Designer Workspace.
+2. Create or open an existing template.
+3. Add text variables with same name as keys of the fileds we're returning from the connector. Assign them to text frames in your template
+3. Open Data Source Panel and select your connector.
+4. Go to "Run" mode
+
+You should see the mock user data displayed in the template
+
+## Conclusion
+
+Congratulations! You've successfully built your first Data Connector for GraFx Studio. This connector allows you to integrate mock user data from Mockaroo into the GraFx Studio Designer Workspace.
+
+### Key Accomplishments
+
+In this tutorial, you've learned how to:
+
+1. Set up a new data connector project
+2. Implement the `getPage` method to fetch and display data
+3. Publish and test your connector in the GraFx Studio
+
+## Next Steps
+
+1. Review the [Comprehensive Connector Documentation](/GraFx-Developers/connectors/connectors-introduction/) for in-depth information on connector functionality and best practices.
+2. Implement proper authorization by following the [Authorization for Connectors](/GraFx-Developers/connectors/authorization-for-connectors/) documentation for production use.

--- a/docs/GraFx-Developers/connectors/data-connector/data-connector-fundamentals/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/data-connector-fundamentals/index.md
@@ -127,6 +127,6 @@ The returned `DataModel` structure is used to define the types of data that your
 
 ## Next Steps
 
-1. Follow the Build a Simple Data Connector (In Progress) tutorial to learn how to build your first Data Connector.
+1. Follow the [Build a Simple Data Connector](/GraFx-Developers/connectors/data-connector/build-a-simple-data-connector/) tutorial to learn how to build your first Data Connector.
 2. Review the [Authorization for Connectors](/GraFx-Developers/connectors/authorization-for-connectors/) for understanding how to add authorization to your Connector.
 3. Explore the [Connector CLI](/GraFx-Developers/connectors/connector-cli/) documentation to learn about the tools available for connector development.

--- a/docs/GraFx-Developers/connectors/data-connector/data-connector-fundamentals/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/data-connector-fundamentals/index.md
@@ -1,0 +1,132 @@
+# Data Connector Fundamentals
+
+A Data Connector is a JavaScript class that implements the `Data.DataConnector` interface, providing methods utilized by the Studio Engine and the Studio SDK. This guide offers a high-level overview of Data Connectors.
+
+## Requirements
+
+- Basic understanding of modern JavaScript
+- Familiarity with asynchronous programming (Promises)
+- Basic experience with the GraFx Studio Template Designer Workspace
+
+## Isolation
+
+Data Connectors run in a limited isolated environment, which means they don't have access to many browser APIs or Node.js APIs. This isolation serves two primary purposes:
+
+1. **Security**: JavaScript runs on the server, so it's crucial that it cannot directly access APIs that could compromise customer data.
+2. **Performance**: By limiting available APIs, scripts remain small and easier to optimize for performance.
+
+Due to this isolation, you cannot access the `window` object or many commonly used methods like `console.log`.
+
+## Runtime
+
+Instead of browser globals, Connectors use a `ConnectorRuntimeContext`, which is passed to the constructor of a Connector class. It's common practice to store this on a `runtime` property:
+
+```typescript
+export default class MyConnector implements Data.DataConnector {
+  private runtime: Connector.ConnectorRuntimeContext;
+
+  constructor(runtime: Connector.ConnectorRuntimeContext) {
+    this.runtime = runtime;
+  }
+}
+```
+
+The `runtime` object provides methods like `fetch` and `logError` to replace similar functionality found in browser environments.
+
+## Connector Methods
+
+Your Data Connector class needs to implement four key methods:
+
+1. getCapabilities
+2. getConfigurationOptions
+3. getPage
+4. getModel (optional, based on capabilities)
+
+### getCapabilities Method
+
+This method communicates to the SDK what features the Connector supports:
+
+```typescript
+getCapabilities(): Data.DataConnectorCapabilities {
+  return {
+    filtering: false,
+    sorting: false,
+    model: false,
+  };
+}
+```
+
+### getConfigurationOptions Method
+
+The `getConfigurationOptions` method allows Connector developers to define customizable settings that template designers can use to modify the behavior of the Connector.
+
+```typescript
+getConfigurationOptions(): Connector.ConnectorConfigValue[] | null {
+  return [{
+    name: "example",
+    displayName: "Displayed In UI",
+    type: "text"
+  }];
+}
+```
+
+When you define configuration options in this method, you're essentially telling the SDK, "My Connector supports these customization options." These values can then be accessed and utilized in other methods of your Connector through the `context` argument.
+
+### getPage Method
+
+The `getPage` method is responsible for retrieving a specific page of data from your data source. It's called when a template loads initially and subsequently whenever pagination is required to fetch the next batch of data items. This method handles the core data retrieval functionality of your connector.
+
+```typescript
+async getPage(
+  config: Data.PageConfig,
+  context: Connector.Dictionary
+): Promise<Data.DataPage> {
+  // Implement your data retrieval logic here
+}
+```
+
+The `PageConfig` interface includes:
+
+```typescript
+interface PageConfig {
+    continuationToken?: string | null; // Optional token for pagination
+    limit: number; // Maximum number of items to return
+}
+```
+
+The method should return a `DataPage` object:
+
+```typescript
+interface DataPage {
+    data: DataItem[]; // Array of data items
+    continuationToken?: string | null; // Optional token for the next page
+}
+```
+
+!!! note
+
+    The returned `continuationToken` in the `DataPage` is meant to be passed back as `continuationToken` during pagination
+
+### getModel Method
+
+The `getModel` method is used to retrieve the data model of your data source. This method should only be implemented if you have set `model: true` in your connector's capabilities.
+
+```typescript
+async getModel(context: Connector.Dictionary): Promise<Data.DataModel> {
+  // Implement your model retrieval logic here
+}
+```
+
+The returned `DataModel` structure is used to define the types of data that your connector will return. Each property in the model represents a field in your data with its corresponding type:
+
+- `number`: For numeric values
+- `boolean`: For true/false values
+- `singleLine`: For single-line text
+- `multiLine`: For multi-line text
+- `date`: For date values
+
+## Next Steps
+
+1. Follow the Build a Simple Data Connector (In Progress) tutorial to learn how to build your first Data Connector.
+2. Review the [Authorization for Connectors](/GraFx-Developers/connectors/authorization-for-connectors/) for understanding how to add authorization to your Connector.
+3. Explore the [Connector CLI](/GraFx-Developers/connectors/connector-cli/) documentation to learn about the tools available for connector development.

--- a/docs/GraFx-Developers/connectors/data-connector/data-connector-introduction/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/data-connector-introduction/index.md
@@ -8,7 +8,7 @@ Data Connectors are particularly valuable for creating dynamic templates that ca
 
 CHILI publish and our community have developed several Data Connectors to enhance the functionality of GraFx Studio. Some common use cases include:
 
-- [Google Sheets Connector](/GraFx-Studio/connectors/connector-google-sheets-data): Import data from spreadsheet files
+- [Google Sheets Connector](/GraFx-Studio/connectors/connector-google-sheets-data/): Import data from spreadsheet files
 
 ## Tutorial Sequence
 

--- a/docs/GraFx-Developers/connectors/data-connector/data-connector-introduction/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/data-connector-introduction/index.md
@@ -15,9 +15,7 @@ CHILI publish and our community have developed several Data Connectors to enhanc
 For those new to building Data Connectors, we recommend following this structured learning path:
 
 1. [Data Connector Fundamentals](/GraFx-Developers/connectors/data-connector/data-connector-fundamentals/): Learn the basic concepts and architecture of Data Connectors.
-2. Build a Simple Data Connector (In progress): Create your first Data Connector with step-by-step guidance.
-3. Add Variable Settings To Your Connector(In progress): Enhance your connector with customizable settings.
-4. Add Environment Options To Your Connector(In progress): Learn to configure your connector for different environments.
+2. [Build a Simple Data Connector](/GraFx-Developers/connectors/data-connector/build-a-simple-data-connector/): Create your first Data Connector with step-by-step guidance.
 
 ## Reference Documentation
 

--- a/docs/GraFx-Developers/connectors/data-connector/data-connector-introduction/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/data-connector-introduction/index.md
@@ -1,0 +1,27 @@
+# Data Connector Introduction
+
+GraFx Studio provides Data Connectors as a powerful way to integrate external data sources into your templates. Data Connectors enable you to dynamically populate your templates with data from various sources such as databases, APIs, or other data services.
+
+Data Connectors are particularly valuable for creating dynamic templates that can be populated with real-time or frequently updated data. This integration allows for the creation of personalized and data-driven documents while maintaining a consistent design.
+
+## Examples of Data Connectors
+
+CHILI publish and our community have developed several Data Connectors to enhance the functionality of GraFx Studio. Some common use cases include:
+
+- [Google Sheets Connector](/GraFx-Studio/connectors/connector-google-sheets-data): Import data from spreadsheet files
+
+## Tutorial Sequence
+
+For those new to building Data Connectors, we recommend following this structured learning path:
+
+1. [Data Connector Fundamentals](/GraFx-Developers/connectors/data-connector/data-connector-fundamentals/): Learn the basic concepts and architecture of Data Connectors.
+2. Build a Simple Data Connector (In progress): Create your first Data Connector with step-by-step guidance.
+3. Add Variable Settings To Your Connector(In progress): Enhance your connector with customizable settings.
+4. Add Environment Options To Your Connector(In progress): Learn to configure your connector for different environments.
+
+## Reference Documentation
+
+To deepen your understanding and for quick access to specific information, refer to these resources:
+
+- [Authorization for Connectors](/GraFx-Developers/connectors/authorization-for-connectors/): Understand the authentication and authorization processes for secure connector integration.
+- [Connector CLI](/GraFx-Developers/connectors/connector-cli/): Learn about the Command Line Interface tools available for connector development and management.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -445,5 +445,8 @@ nav:
                 - 'Build a Simple Connector': 'GraFx-Developers/connectors/media-connector/build-a-simple-media-connector/index.md'
                 - 'Add Configuration Options To Your Connector': 'GraFx-Developers/connectors/media-connector/add-variable-settings-to-your-connector/index.md'
                 - 'Add Environment Options To Your Connector': 'GraFx-Developers/connectors/media-connector/add-environment-options-to-your-connector/index.md'
+            - 'Data Connectors':
+                - 'Introduction': 'GraFx-Developers/connectors/data-connector/data-connector-introduction/index.md'
+                - 'Data Connector Fundamentals': 'GraFx-Developers/connectors/data-connector/data-connector-fundamentals/index.md'
             - 'Authorization for Connectors': 'GraFx-Developers/connectors/authorization-for-connectors/index.md'
             - 'Publish my connector':                         'GraFx-Developers/connectors/publish-my-connector/index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -448,5 +448,6 @@ nav:
             - 'Data Connectors':
                 - 'Introduction': 'GraFx-Developers/connectors/data-connector/data-connector-introduction/index.md'
                 - 'Data Connector Fundamentals': 'GraFx-Developers/connectors/data-connector/data-connector-fundamentals/index.md'
+                - 'Build a Simple Connector': 'GraFx-Developers/connectors/data-connector/build-a-simple-data-connector/index.md'
             - 'Authorization for Connectors': 'GraFx-Developers/connectors/authorization-for-connectors/index.md'
             - 'Publish my connector':                         'GraFx-Developers/connectors/publish-my-connector/index.md'


### PR DESCRIPTION
The PR brings documentation for data connectors. It includes following sections
- Introduction
- Data Connectors fundamentals
- Build a Simple Connector (Integration with Muckaroo)

Advanced settings (Connector Configuration and Runtime options) can be added later if needed