### PR TITLE
[LLMS txt] Update

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,7 +84,8 @@ plugins:
 
         For prospects and evaluators: CHILI GraFx enables scalable graphic production from a single Design System -
         covering data-driven batch output (hundreds or thousands of variants without manual effort), self-serve brand
-        portals (local marketers and field teams adapt pre-approved designs within brand guardrails), and multichannel
+        portals (local marketers and field teams adapt pre-approved designs within brand guardrails — delivered through
+        GraFx Experience, the end-user application where users browse templates, personalise them, and generate output), and multichannel
         output (print-ready PDF, digital static images, animated video as MP4/GIF, and HTML - all from one Design System
         using Layouts with Print, Digital static, and Digital animated intents).
         Brand governance is enforced through Brand Kits (centrally managed colors, fonts, and paragraph styles)


### PR DESCRIPTION
GraFx Experience was absent from the markdown_description, leaving LLM tools with no knowledge of the end-user-facing product. Added as a parenthetical clause within the existing self-serve brand portals sentence — minimal addition, no structural changes.