### PR TITLE
Fix staging deploy for fork PRs

### DIFF
--- a/.github/workflows/accept-fork.yml
+++ b/.github/workflows/accept-fork.yml
@@ -5,10 +5,18 @@ on:
     types: [labeled]
 
 jobs:
-  build_and_deploy_job:
+  save-pr-info:
     if: github.event.label.name == 'Accept for Deploy'
     runs-on: ubuntu-latest
-    name: Accept
+    name: Save PR info for fork deploy
     steps:
-      - name: Accept
-        run: echo "Accepted"
+      - name: Save PR data
+        run: |
+          mkdir -p ./pr
+          echo "${{ github.event.pull_request.number }}"   > ./pr/number
+          echo "${{ github.event.pull_request.head.sha }}" > ./pr/sha
+      - name: Upload PR info artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
@@ -11,8 +11,14 @@ on:
 
 jobs:
   build_and_deploy_job:
-    # if non forked PR, run the deploy
-    if: github.repository == 'chili-publish/grafx-documentation' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed'))
+    # Run for pushes to main, and for PRs only when the head is in this same repo.
+    # Fork PRs are handled separately by deploy-fork.yml after a maintainer applies
+    # the "Accept for Deploy" label.
+    if: |
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request'
+       && github.event.action != 'closed'
+       && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/.github/workflows/deploy-fork.yml
+++ b/.github/workflows/deploy-fork.yml
@@ -1,48 +1,55 @@
 name: Deploy fork PR to dev
 
 on:
-  workflow_run: 
+  workflow_run:
     workflows: [Apply Deploy Label]
     types:
       - completed
 
 jobs:
   build_and_deploy_job:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    name: Build and Deploy Job
+    name: Build and Deploy Fork PR
     steps:
-      - uses: actions/checkout@v6
+      - name: Download PR info
+        uses: actions/download-artifact@v4
         with:
+          name: pr
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR info
+        id: pr
+        run: |
+          echo "number=$(cat number)" >> $GITHUB_OUTPUT
+          echo "sha=$(cat sha)"       >> $GITHUB_OUTPUT
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
           submodules: true
-      - uses: actions/setup-python@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
+
       - name: Install MkDocs
         run: pip install -r requirements.txt
-      - name:  build documentation 
-        run: mkdocs build   
-      - name: copy config file
-        run: cp staticwebapp.config.json site   
-      - name: Deploy to azure
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Copy config file
+        run: cp staticwebapp.config.json site
+
+      - name: Deploy to Azure
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WONDERFUL_SKY_012B9BC03 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/site" # App source code path
-          ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WONDERFUL_SKY_012B9BC03 }}
-          action: "close"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: /site


### PR DESCRIPTION
accept-fork.yml: job renamed to save-pr-info, writes PR number + head SHA to ./pr/, uploads as pr artifact (was a no-op echo "Accepted").
deploy-fork.yml: workflow_run trigger gated on conclusion == 'success', downloads the pr artifact, reads number/sha into step outputs, checks out with ref: ${{ steps.pr.outputs.sha }}, then build + Azure deploy. Old close_pull_request_job removed (couldn't fire on workflow_run).
azure-static-web-apps-wonderful-sky-012b9bc03.yml: only the if: on build_and_deploy_job changed — now allows push OR same-repo PRs via head.repo.full_name == github.repository. close_pull_request_job untouched.