### PR TITLE
[Repo] Offload Binary Assets

### DIFF
--- a/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
@@ -82,20 +82,21 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
+          # No `subscriptionId` in the creds JSON: the Product CI/CD SP has
+          # only data-plane (Storage Blob Data Contributor) access on the
+          # docs-cdn storage account; it isn't enrolled in any subscription's
+          # IAM. If we pass subscriptionId, azure/login adds `--subscription`
+          # to `az login` and fails because the SP can't see that
+          # subscription. `allow-no-subscriptions: true` lets login succeed
+          # without any subscription context. All our `az storage blob`
+          # calls use --auth-mode login (data plane) and target a specific
+          # account by name, so no subscription is needed.
           creds: >-
             {
               "clientId":       "${{ vars.AZ_AD_CLIENT_ID_CP_PDT_INT_CICD_SP }}",
               "clientSecret":   "${{ secrets.AZ_AD_CLIENT_SECRET_CP_PDT_INT_CICD_SP }}",
-              "tenantId":       "${{ vars.AZ_TENANT_ID }}",
-              "subscriptionId": "${{ vars.AZ_SUBSCRIPTION_ID_GRAFX_PRD }}"
+              "tenantId":       "${{ vars.AZ_TENANT_ID }}"
             }
-          # The Product CI/CD SP has Storage Blob Data Contributor on the
-          # docs-cdn storage account (data-plane) but isn't enrolled in the
-          # subscription's IAM. Without this flag, azure/login fails when it
-          # tries to set the subscription as the active context. We don't
-          # actually need subscription context -- all our `az storage blob`
-          # calls use --auth-mode login (data plane) and target a specific
-          # account by name.
           allow-no-subscriptions: true
 
       - name: Collect CDN assets from site/ into a staging dir

--- a/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
@@ -89,6 +89,14 @@ jobs:
               "tenantId":       "${{ vars.AZ_TENANT_ID }}",
               "subscriptionId": "${{ vars.AZ_SUBSCRIPTION_ID_GRAFX_PRD }}"
             }
+          # The Product CI/CD SP has Storage Blob Data Contributor on the
+          # docs-cdn storage account (data-plane) but isn't enrolled in the
+          # subscription's IAM. Without this flag, azure/login fails when it
+          # tries to set the subscription as the active context. We don't
+          # actually need subscription context -- all our `az storage blob`
+          # calls use --auth-mode login (data plane) and target a specific
+          # account by name.
+          allow-no-subscriptions: true
 
       - name: Collect CDN assets from site/ into a staging dir
         run: python3 scripts/cdn/collect_assets.py site/ build/cdn-upload/

--- a/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
@@ -42,10 +42,126 @@ jobs:
           python-version: 3.x
       - name: Install MkDocs
         run: pip install -r requirements.txt
-      - name:  build documentation 
-        run: mkdocs build   
-      - name: copy config file
-        run: cp staticwebapp.config.json site   
+      - name: Build documentation
+        run: mkdocs build
+
+      # ===== CDN offload pipeline (DT-973) =====
+      # Binary assets (png/jpg/svg/gif/mp4/webm/pdf/webp) are served from
+      # docs-cdn.chiligrafx.com; the SWA artifact only carries HTML/CSS/JS.
+      # See scripts/cdn/ for the underlying tools and the design notes in
+      # the DT-973 ticket.
+
+      - name: Compute CDN target
+        id: cdn
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            echo "container=assets" >> "$GITHUB_OUTPUT"
+            echo "dest_path=" >> "$GITHUB_OUTPUT"
+            echo "url_prefix=/assets/" >> "$GITHUB_OUTPUT"
+            echo "is_main=true" >> "$GITHUB_OUTPUT"
+          else
+            PR_NUM="${{ github.event.pull_request.number }}"
+            echo "container=staging" >> "$GITHUB_OUTPUT"
+            echo "dest_path=pr-$PR_NUM/assets/" >> "$GITHUB_OUTPUT"
+            echo "url_prefix=/staging/pr-$PR_NUM/assets/" >> "$GITHUB_OUTPUT"
+            echo "is_main=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: >-
+            {
+              "clientId":       "${{ vars.AZ_AD_CLIENT_ID_CP_PDT_INT_CICD_SP }}",
+              "clientSecret":   "${{ secrets.AZ_AD_CLIENT_SECRET_CP_PDT_INT_CICD_SP }}",
+              "tenantId":       "${{ vars.AZ_TENANT_ID }}",
+              "subscriptionId": "${{ vars.AZ_SUBSCRIPTION_ID_GRAFX_PRD }}"
+            }
+
+      - name: Collect CDN assets from site/ into a staging dir
+        run: python3 scripts/cdn/collect_assets.py site/ build/cdn-upload/
+
+      - name: Upload assets to blob
+        uses: azure/cli@v2
+        with:
+          inlineScript: |
+            az storage blob upload-batch \
+              --account-name "${{ vars.DOCS_CDN_STORAGE_ACCOUNT_NAME }}" \
+              --destination "${{ steps.cdn.outputs.container }}" \
+              --destination-path "${{ steps.cdn.outputs.dest_path }}" \
+              --source build/cdn-upload/ \
+              --overwrite true \
+              --auth-mode login
+
+      # ---- Inline orphan deletion (main branch only) ----
+      # PR builds use a fresh per-PR prefix in the staging container, so there
+      # are no orphans to delete -- the lifecycle policy on `pr-*` purges them
+      # entirely after 30 days.
+
+      - name: List current blobs in /assets/ (main only)
+        if: steps.cdn.outputs.is_main == 'true'
+        uses: azure/cli@v2
+        with:
+          inlineScript: |
+            az storage blob list \
+              --account-name "${{ vars.DOCS_CDN_STORAGE_ACCOUNT_NAME }}" \
+              --container-name assets \
+              --auth-mode login \
+              --query "[].name" -o tsv | sort > current.txt
+            echo "Remote blob count: $(wc -l < current.txt)"
+
+      - name: Compute orphans with safety guards (main only)
+        if: steps.cdn.outputs.is_main == 'true'
+        run: |
+          (cd build/cdn-upload && find . -type f | sed 's|^\./||') | sort > expected.txt
+          comm -23 current.txt expected.txt > orphans.txt
+          expected_count=$(wc -l < expected.txt)
+          orphan_count=$(wc -l < orphans.txt)
+          echo "Expected files in build: $expected_count"
+          echo "Orphans to delete: $orphan_count"
+          # Guard 1: a sane build should have >= 500 in-scope files.
+          if [ "$expected_count" -lt 500 ]; then
+            echo "::error::Refusing to delete: expected tree has fewer than 500 files ($expected_count). Aborting before any deletes."
+            exit 1
+          fi
+          # Guard 2: a normal main build deletes ~0-5 files; a sudden spike
+          # almost certainly indicates a bug in the diff or in the build.
+          if [ "$orphan_count" -gt 50 ]; then
+            echo "::error::Refusing to delete: would remove $orphan_count blobs in one run (>50). Aborting before any deletes."
+            exit 1
+          fi
+
+      - name: Delete orphan blobs (main only)
+        if: steps.cdn.outputs.is_main == 'true'
+        uses: azure/cli@v2
+        with:
+          inlineScript: |
+            if [ ! -s orphans.txt ]; then
+              echo "No orphans to delete"
+              exit 0
+            fi
+            while IFS= read -r blob; do
+              echo "Deleting orphan: $blob"
+              az storage blob delete \
+                --account-name "${{ vars.DOCS_CDN_STORAGE_ACCOUNT_NAME }}" \
+                --container-name assets --name "$blob" --auth-mode login
+            done < orphans.txt
+
+      - name: Rewrite asset references in HTML to CDN URLs (strict)
+        run: |
+          python3 scripts/cdn/rewrite_urls.py \
+            site/ \
+            https://docs-cdn.chiligrafx.com \
+            "${{ steps.cdn.outputs.url_prefix }}" \
+            --strict
+
+      - name: Strip binary assets from SWA upload
+        run: python3 scripts/cdn/strip_assets.py site/
+
+      # ===== End CDN offload pipeline =====
+
+      - name: Copy SWA config file
+        run: cp staticwebapp.config.json site
       - name: Deploy to azure
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
@@ -20,6 +20,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Least-privilege default for GITHUB_TOKEN; per-job blocks below grant only
+# what's actually needed.
+permissions: {}
+
 
 jobs:
   build_and_deploy_job:
@@ -33,10 +37,18 @@ jobs:
        && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    # Checkout needs `contents: read`. SWA action posts preview-URL comment on
+    # PRs, which needs `pull-requests: write`. Nothing else GITHUB_TOKEN here.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          # GITHUB_TOKEN is not used by any later step; don't persist it in
+          # .git/config where it could leak to other tooling.
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -178,6 +190,8 @@ jobs:
     if: github.repository == 'chili-publish/grafx-documentation' && github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    # SWA close action uses its own API token; no GITHUB_TOKEN scopes needed.
+    permissions: {}
     steps:
       - name: Close Pull Request
         id: closepullrequest

--- a/.github/workflows/deploy-fork.yml
+++ b/.github/workflows/deploy-fork.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.sha }}
           submodules: true
+          # GITHUB_TOKEN is not used by any later git command; don't persist
+          # it in .git/config where it could leak to other tooling.
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/deploy-fork.yml
+++ b/.github/workflows/deploy-fork.yml
@@ -73,6 +73,9 @@ jobs:
               "tenantId":       "${{ vars.AZ_TENANT_ID }}",
               "subscriptionId": "${{ vars.AZ_SUBSCRIPTION_ID_GRAFX_PRD }}"
             }
+          # See azure-static-web-apps-...yml for explanation -- our SP has
+          # data-plane access only, no subscription IAM membership.
+          allow-no-subscriptions: true
 
       - name: Collect CDN assets from site/ into a staging dir
         run: python3 scripts/cdn/collect_assets.py site/ build/cdn-upload/

--- a/.github/workflows/deploy-fork.yml
+++ b/.github/workflows/deploy-fork.yml
@@ -54,6 +54,51 @@ jobs:
       - name: Build documentation
         run: mkdocs build
 
+      # ===== CDN offload pipeline (DT-973) =====
+      # Fork PRs always upload to the `staging` container, prefixed by PR
+      # number (matches the same-repo PR layout from the main workflow).
+      # No orphan-delete step here -- staging is per-PR and gets cleaned by
+      # the lifecycle policy.
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: >-
+            {
+              "clientId":       "${{ vars.AZ_AD_CLIENT_ID_CP_PDT_INT_CICD_SP }}",
+              "clientSecret":   "${{ secrets.AZ_AD_CLIENT_SECRET_CP_PDT_INT_CICD_SP }}",
+              "tenantId":       "${{ vars.AZ_TENANT_ID }}",
+              "subscriptionId": "${{ vars.AZ_SUBSCRIPTION_ID_GRAFX_PRD }}"
+            }
+
+      - name: Collect CDN assets from site/ into a staging dir
+        run: python3 scripts/cdn/collect_assets.py site/ build/cdn-upload/
+
+      - name: Upload assets to staging blob
+        uses: azure/cli@v2
+        with:
+          inlineScript: |
+            az storage blob upload-batch \
+              --account-name "${{ vars.DOCS_CDN_STORAGE_ACCOUNT_NAME }}" \
+              --destination staging \
+              --destination-path "pr-${{ steps.pr.outputs.number }}/assets/" \
+              --source build/cdn-upload/ \
+              --overwrite true \
+              --auth-mode login
+
+      - name: Rewrite asset references in HTML to CDN URLs (strict)
+        run: |
+          python3 scripts/cdn/rewrite_urls.py \
+            site/ \
+            https://docs-cdn.chiligrafx.com \
+            "/staging/pr-${{ steps.pr.outputs.number }}/assets/" \
+            --strict
+
+      - name: Strip binary assets from SWA upload
+        run: python3 scripts/cdn/strip_assets.py site/
+
+      # ===== End CDN offload pipeline =====
+
       - name: Copy config file
         run: cp staticwebapp.config.json site
 

--- a/.github/workflows/deploy-fork.yml
+++ b/.github/workflows/deploy-fork.yml
@@ -66,15 +66,15 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
+          # See azure-static-web-apps-...yml for the full explanation: our SP
+          # has only data-plane access, no subscription IAM membership, so
+          # we omit subscriptionId from creds and set allow-no-subscriptions.
           creds: >-
             {
               "clientId":       "${{ vars.AZ_AD_CLIENT_ID_CP_PDT_INT_CICD_SP }}",
               "clientSecret":   "${{ secrets.AZ_AD_CLIENT_SECRET_CP_PDT_INT_CICD_SP }}",
-              "tenantId":       "${{ vars.AZ_TENANT_ID }}",
-              "subscriptionId": "${{ vars.AZ_SUBSCRIPTION_ID_GRAFX_PRD }}"
+              "tenantId":       "${{ vars.AZ_TENANT_ID }}"
             }
-          # See azure-static-web-apps-...yml for explanation -- our SP has
-          # data-plane access only, no subscription IAM membership.
           allow-no-subscriptions: true
 
       - name: Collect CDN assets from site/ into a staging dir

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 .DS_Store
 /site
+/build
 /temp
 /__pycache__
 *.pyc

--- a/scripts/cdn/_assets.py
+++ b/scripts/cdn/_assets.py
@@ -1,0 +1,16 @@
+"""
+Shared constants for the CDN offload scripts (DT-973).
+
+Single source of truth for the asset extension set used by:
+- collect_assets.py  (decides which files go into the upload staging dir)
+- rewrite_urls.py    (decides which HTML refs to rewrite + scan in --strict)
+- strip_assets.py    (decides which files to remove from site/ post-rewrite)
+
+Keep this list in one place so all three scripts stay in sync as we add or
+remove extensions.
+"""
+
+ASSET_EXTS = frozenset({
+    ".png", ".jpg", ".jpeg", ".gif", ".svg",
+    ".mp4", ".webm", ".pdf", ".webp",
+})

--- a/scripts/cdn/collect_assets.py
+++ b/scripts/cdn/collect_assets.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Copy in-scope asset files from a mkdocs `site/` build into a clean staging
+directory, preserving the relative path structure.
+
+Used by the CDN-offload workflow (DT-973) to assemble the exact set of blobs
+to upload to Azure Blob Storage. Kept simple on purpose — extension match,
+recursive walk, copy.
+
+Usage:
+  python3 scripts/cdn/collect_assets.py <site_dir> <staging_dir>
+
+Example:
+  python3 scripts/cdn/collect_assets.py site/ build/cdn-upload/
+"""
+import shutil
+import sys
+from pathlib import Path
+
+ASSET_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".mp4", ".webm", ".pdf", ".webp"}
+
+if len(sys.argv) != 3:
+    print(__doc__)
+    sys.exit(1)
+
+src = Path(sys.argv[1]).resolve()
+dst = Path(sys.argv[2]).resolve()
+
+if not src.is_dir():
+    print(f"Source is not a directory: {src}", file=sys.stderr)
+    sys.exit(1)
+
+# Wipe and recreate the staging dir so stale files from previous runs don't linger
+if dst.exists():
+    shutil.rmtree(dst)
+dst.mkdir(parents=True)
+
+count = 0
+total_bytes = 0
+counts_by_ext: dict[str, int] = {}
+
+for path in src.rglob("*"):
+    if not path.is_file():
+        continue
+    ext = path.suffix.lower()
+    if ext not in ASSET_EXTS:
+        continue
+    rel = path.relative_to(src)
+    target = dst / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(path, target)
+    count += 1
+    total_bytes += path.stat().st_size
+    counts_by_ext[ext] = counts_by_ext.get(ext, 0) + 1
+
+mb = total_bytes / 1024 / 1024
+print(f"Copied {count} files, {mb:.1f} MB into {dst}")
+for ext, n in sorted(counts_by_ext.items(), key=lambda kv: -kv[1]):
+    print(f"  {ext}: {n}")

--- a/scripts/cdn/collect_assets.py
+++ b/scripts/cdn/collect_assets.py
@@ -17,7 +17,7 @@ import shutil
 import sys
 from pathlib import Path
 
-ASSET_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".mp4", ".webm", ".pdf", ".webp"}
+from _assets import ASSET_EXTS
 
 if len(sys.argv) != 3:
     print(__doc__)

--- a/scripts/cdn/rewrite_urls.py
+++ b/scripts/cdn/rewrite_urls.py
@@ -46,10 +46,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-ASSET_EXTS = {
-    ".png", ".jpg", ".jpeg", ".gif", ".svg",
-    ".mp4", ".webm", ".pdf", ".webp",
-}
+from _assets import ASSET_EXTS
 
 # HTML attributes that may carry a URL we want to rewrite.
 # Matches: foo="...", foo='...'
@@ -73,10 +70,23 @@ def is_external(url: str) -> bool:
     ))
 
 
+def split_url_suffix(url: str) -> tuple[str, str]:
+    """Split URL into (path_part, suffix) where suffix is ?query and/or #fragment.
+
+    Returns ("", "") for the empty string. Suffix is empty when there is no
+    query or fragment. Keeping these intact lets the rewriter preserve
+    cache-busting hints (foo.png?v=2) and SVG fragment selectors (sprite.svg#icon).
+    """
+    for i, ch in enumerate(url):
+        if ch in ("?", "#"):
+            return url[:i], url[i:]
+    return url, ""
+
+
 def url_ext(url: str) -> str:
     """Return lowercase extension, stripped of query/fragment."""
-    clean = url.split("?", 1)[0].split("#", 1)[0]
-    return Path(clean).suffix.lower()
+    path_part, _ = split_url_suffix(url)
+    return Path(path_part).suffix.lower()
 
 
 def resolve_site_rel(url: str, host_file: Path, site_root: Path) -> Path | None:
@@ -127,15 +137,18 @@ class Rewriter:
         """Return rewritten URL if we should, else the original."""
         if is_external(url):
             return url
-        ext = url_ext(url)
+        # Split off ?query / #fragment up-front so we can reattach to the CDN
+        # URL at the end -- preserves things like sprite.svg#icon and ?v=hash.
+        path_part, suffix = split_url_suffix(url)
+        ext = Path(path_part).suffix.lower()
         if ext not in ASSET_EXTS:
             return url
-        rel = resolve_site_rel(url, host_file, self.site_root)
+        rel = resolve_site_rel(path_part, host_file, self.site_root)
         if rel is None:
             # Asset extension but resolves outside site/ — leave it, flag in strict.
             self.unresolved.append((host_file, url))
             return url
-        new = build_cdn_url(rel, self.cdn_base, self.path_prefix)
+        new = build_cdn_url(rel, self.cdn_base, self.path_prefix) + suffix
         self.rewrites_total += 1
         self.rewrites_by_ext[ext] += 1
         if self.verbose:

--- a/scripts/cdn/rewrite_urls.py
+++ b/scripts/cdn/rewrite_urls.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Rewrite asset references in a mkdocs `site/` build to point at the CDN.
+
+Walks every .html file (and optionally .xml / .css) in the site dir, finds
+every reference to a binary asset that exists in the build, and replaces it
+with an absolute CDN URL. Skips already-absolute URLs (http/https/data/etc.)
+and references that don't have an asset extension we care about.
+
+After this runs, site/ still contains the binaries — strip them with
+scripts/cdn/strip_assets.py (or an equivalent `find ... -delete`) before the
+SWA deploy.
+
+Usage:
+  python3 scripts/cdn/rewrite_urls.py <site_dir> <cdn_base> <path_prefix> [options]
+
+Arguments:
+  site_dir      Root of the mkdocs build (e.g. site/)
+  cdn_base      CDN base URL (e.g. https://docs-cdn.chiligrafx.com)
+  path_prefix   Container + optional sub-prefix between cdn_base and the
+                site-relative path. Leading/trailing slashes are normalised.
+                Examples:
+                  /assets/                            (prod)
+                  /staging/pr-482/assets/             (PR preview)
+
+Options:
+  --strict          Fail with exit code 2 if any unrewritten reference still
+                    points at an in-scope asset extension. Recommended in CI.
+  --dry-run         Don't modify files; just report what would change.
+  --include-css     Also rewrite url(...) references in .css files.
+  --include-xml     Also rewrite asset URLs in .xml files (sitemap, RSS).
+                    Default: enabled.
+  --no-include-xml  Disable .xml processing.
+  --verbose         Print every individual rewrite (lots of output).
+
+Exit codes:
+  0  Success
+  1  Bad arguments / IO error
+  2  --strict found unrewritten asset references
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ASSET_EXTS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".svg",
+    ".mp4", ".webm", ".pdf", ".webp",
+}
+
+# HTML attributes that may carry a URL we want to rewrite.
+# Matches: foo="...", foo='...'
+# Captures: 1=attr name, 2=quote char, 3=url-or-srcset-payload
+HTML_ATTR_RE = re.compile(
+    r'\b(src|href|content|poster|srcset)\s*=\s*(["\'])([^"\']*)\2'
+)
+
+# CSS url() — handles quoted and unquoted forms.
+# Captures: 1=quote (maybe empty), 2=url
+CSS_URL_RE = re.compile(
+    r'url\(\s*(["\']?)([^"\')\s]+)\1\s*\)'
+)
+
+
+def is_external(url: str) -> bool:
+    """URL is external / special; never rewrite."""
+    return url.startswith((
+        "http://", "https://", "//", "data:", "mailto:", "tel:",
+        "#", "javascript:",
+    ))
+
+
+def url_ext(url: str) -> str:
+    """Return lowercase extension, stripped of query/fragment."""
+    clean = url.split("?", 1)[0].split("#", 1)[0]
+    return Path(clean).suffix.lower()
+
+
+def resolve_site_rel(url: str, host_file: Path, site_root: Path) -> Path | None:
+    """Resolve a relative URL against the file's directory, return path
+    relative to site_root, or None if it falls outside."""
+    clean = url.split("?", 1)[0].split("#", 1)[0]
+    if clean.startswith("/"):
+        # site-absolute path
+        target = (site_root / clean.lstrip("/")).resolve()
+    else:
+        target = (host_file.parent / clean).resolve()
+    try:
+        return target.relative_to(site_root)
+    except ValueError:
+        return None
+
+
+def build_cdn_url(rel: Path, cdn_base: str, path_prefix: str) -> str:
+    return f"{cdn_base.rstrip('/')}{path_prefix}{rel.as_posix()}"
+
+
+class Rewriter:
+    def __init__(
+        self,
+        site_root: Path,
+        cdn_base: str,
+        path_prefix: str,
+        strict: bool,
+        dry_run: bool,
+        verbose: bool,
+    ):
+        self.site_root = site_root
+        self.cdn_base = cdn_base
+        # Normalise prefix: always one leading and one trailing slash.
+        self.path_prefix = "/" + path_prefix.strip("/") + "/"
+        self.strict = strict
+        self.dry_run = dry_run
+        self.verbose = verbose
+        # Stats
+        self.files_modified = 0
+        self.files_scanned = 0
+        self.rewrites_total = 0
+        self.rewrites_by_ext: dict[str, int] = defaultdict(int)
+        # Strict-mode collector
+        self.unresolved: list[tuple[Path, str]] = []
+
+    def _maybe_rewrite(self, url: str, host_file: Path) -> str:
+        """Return rewritten URL if we should, else the original."""
+        if is_external(url):
+            return url
+        ext = url_ext(url)
+        if ext not in ASSET_EXTS:
+            return url
+        rel = resolve_site_rel(url, host_file, self.site_root)
+        if rel is None:
+            # Asset extension but resolves outside site/ — leave it, flag in strict.
+            self.unresolved.append((host_file, url))
+            return url
+        new = build_cdn_url(rel, self.cdn_base, self.path_prefix)
+        self.rewrites_total += 1
+        self.rewrites_by_ext[ext] += 1
+        if self.verbose:
+            rel_host = host_file.relative_to(self.site_root)
+            print(f"  {rel_host}: {url} -> {new}", file=sys.stderr)
+        return new
+
+    def _rewrite_srcset(self, payload: str, host_file: Path) -> str:
+        """srcset is `url descriptor, url descriptor, ...`."""
+        new_parts = []
+        for part in payload.split(","):
+            stripped = part.strip()
+            if not stripped:
+                continue
+            bits = stripped.split(None, 1)
+            u = bits[0]
+            rest = (" " + bits[1]) if len(bits) > 1 else ""
+            new_parts.append(self._maybe_rewrite(u, host_file) + rest)
+        return ", ".join(new_parts)
+
+    def _process_attrs(self, content: str, host_file: Path) -> str:
+        def replace(m: re.Match) -> str:
+            attr, quote, payload = m.group(1), m.group(2), m.group(3)
+            if attr == "srcset":
+                new_payload = self._rewrite_srcset(payload, host_file)
+            else:
+                new_payload = self._maybe_rewrite(payload, host_file)
+            return f"{attr}={quote}{new_payload}{quote}"
+
+        return HTML_ATTR_RE.sub(replace, content)
+
+    def _process_css_urls(self, content: str, host_file: Path) -> str:
+        def replace(m: re.Match) -> str:
+            quote, url = m.group(1), m.group(2)
+            new_url = self._maybe_rewrite(url, host_file)
+            return f"url({quote}{new_url}{quote})"
+
+        return CSS_URL_RE.sub(replace, content)
+
+    def rewrite_file(self, file_path: Path, process_css_urls: bool) -> None:
+        self.files_scanned += 1
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            print(f"warning: skipping {file_path}: {e}", file=sys.stderr)
+            return
+
+        before_total = self.rewrites_total
+        new_content = self._process_attrs(content, file_path)
+        if process_css_urls:
+            new_content = self._process_css_urls(new_content, file_path)
+
+        if new_content != content:
+            self.files_modified += 1
+            if not self.dry_run:
+                file_path.write_text(new_content, encoding="utf-8")
+
+        # Strict mode: scan for remaining in-scope unresolved refs in OUTPUT.
+        if self.strict:
+            for m in HTML_ATTR_RE.finditer(new_content):
+                attr, _, payload = m.group(1), m.group(2), m.group(3)
+                urls = payload.split(",") if attr == "srcset" else [payload]
+                for u in urls:
+                    u = u.strip().split(None, 1)[0] if attr == "srcset" else u
+                    if not is_external(u) and url_ext(u) in ASSET_EXTS:
+                        self.unresolved.append((file_path, u))
+            if process_css_urls:
+                for m in CSS_URL_RE.finditer(new_content):
+                    u = m.group(2)
+                    if not is_external(u) and url_ext(u) in ASSET_EXTS:
+                        self.unresolved.append((file_path, u))
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Rewrite asset references in a mkdocs site/ to CDN URLs.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("site_dir", help="Root of the mkdocs build (e.g. site/)")
+    p.add_argument("cdn_base", help="CDN base URL (e.g. https://docs-cdn.chiligrafx.com)")
+    p.add_argument("path_prefix", help="Path prefix (e.g. /assets/ or /staging/pr-482/assets/)")
+    p.add_argument("--strict", action="store_true",
+                   help="Fail (exit 2) if any in-scope asset refs remain unrewritten.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Don't modify files; just report what would change.")
+    p.add_argument("--include-css", action="store_true",
+                   help="Also rewrite url(...) refs in .css files.")
+    p.add_argument("--include-xml", action=argparse.BooleanOptionalAction, default=True,
+                   help="Also process .xml files (default: enabled).")
+    p.add_argument("--verbose", action="store_true",
+                   help="Print every individual rewrite.")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    site_root = Path(args.site_dir).resolve()
+    if not site_root.is_dir():
+        print(f"error: site_dir is not a directory: {site_root}", file=sys.stderr)
+        return 1
+
+    rewriter = Rewriter(
+        site_root=site_root,
+        cdn_base=args.cdn_base,
+        path_prefix=args.path_prefix,
+        strict=args.strict,
+        dry_run=args.dry_run,
+        verbose=args.verbose,
+    )
+
+    # Build the list of files to process
+    targets: list[tuple[Path, bool]] = []  # (path, process_css_urls)
+    for path in site_root.rglob("*"):
+        if not path.is_file():
+            continue
+        suffix = path.suffix.lower()
+        if suffix == ".html":
+            # HTML: attrs + inline style url() (process_css_urls=True catches both
+            # inline <style> blocks and inline style="..." values).
+            targets.append((path, True))
+        elif suffix == ".xml" and args.include_xml:
+            targets.append((path, False))
+        elif suffix == ".css" and args.include_css:
+            targets.append((path, True))
+
+    for file_path, process_css in targets:
+        rewriter.rewrite_file(file_path, process_css_urls=process_css)
+
+    # Summary
+    print(
+        f"Scanned {rewriter.files_scanned} file(s); "
+        f"modified {rewriter.files_modified}; "
+        f"rewrote {rewriter.rewrites_total} reference(s)."
+        f"{' (dry run, no files written)' if args.dry_run else ''}",
+        file=sys.stderr,
+    )
+    if rewriter.rewrites_by_ext:
+        for ext, n in sorted(rewriter.rewrites_by_ext.items(), key=lambda kv: -kv[1]):
+            print(f"  {ext}: {n}", file=sys.stderr)
+
+    if args.strict and rewriter.unresolved:
+        # Deduplicate
+        seen: set[tuple[str, str]] = set()
+        uniq = []
+        for f, u in rewriter.unresolved:
+            key = (str(f), u)
+            if key in seen:
+                continue
+            seen.add(key)
+            uniq.append((f, u))
+        print(
+            f"\nstrict: {len(uniq)} unresolved asset reference(s):",
+            file=sys.stderr,
+        )
+        for f, u in uniq[:50]:
+            rel = f.relative_to(site_root)
+            print(f"  {rel}: {u}", file=sys.stderr)
+        if len(uniq) > 50:
+            print(f"  ... and {len(uniq) - 50} more", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cdn/strip_assets.py
+++ b/scripts/cdn/strip_assets.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Remove in-scope asset files from a mkdocs `site/` build.
+
+Run after `rewrite_urls.py` so the deployed Azure Static Web Apps artifact
+contains only HTML/CSS/JS/fonts — the binaries are now served from the CDN.
+
+Mirrors the same extension list as `collect_assets.py` and `rewrite_urls.py`
+so the three steps stay in sync.
+
+Usage:
+  python3 scripts/cdn/strip_assets.py <site_dir> [--dry-run]
+
+Options:
+  --dry-run   Report what would be removed, don't delete anything.
+
+Exit codes:
+  0  Success
+  1  Bad arguments / not a directory
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ASSET_EXTS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".svg",
+    ".mp4", ".webm", ".pdf", ".webp",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("site_dir", help="Root of the mkdocs build (e.g. site/)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Don't delete; just report.")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    site = Path(args.site_dir).resolve()
+    if not site.is_dir():
+        print(f"error: site_dir is not a directory: {site}", file=sys.stderr)
+        return 1
+
+    count = 0
+    total_bytes = 0
+    by_ext: dict[str, int] = defaultdict(int)
+
+    for path in site.rglob("*"):
+        if not path.is_file():
+            continue
+        ext = path.suffix.lower()
+        if ext not in ASSET_EXTS:
+            continue
+        total_bytes += path.stat().st_size
+        if not args.dry_run:
+            path.unlink()
+        count += 1
+        by_ext[ext] += 1
+
+    mb = total_bytes / 1024 / 1024
+    verb = "Would remove" if args.dry_run else "Removed"
+    print(f"{verb} {count} file(s), {mb:.1f} MB from {site}", file=sys.stderr)
+    for ext, n in sorted(by_ext.items(), key=lambda kv: -kv[1]):
+        print(f"  {ext}: {n}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cdn/strip_assets.py
+++ b/scripts/cdn/strip_assets.py
@@ -25,10 +25,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-ASSET_EXTS = {
-    ".png", ".jpg", ".jpeg", ".gif", ".svg",
-    ".mp4", ".webm", ".pdf", ".webp",
-}
+from _assets import ASSET_EXTS
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
Move documentation binary assets out of the SWA bundle and onto the
docs-cdn.chiligrafx.com CDN (Azure Blob Storage). The SWA artifact has
been hitting its size limit because of binary assets (PNG/JPG/SVG/GIF/
MP4/PDF) bundled with the rendered site.

What this PR adds:
- Three small scripts under scripts/cdn/ (stdlib-only Python):
  collect_assets, rewrite_urls (with --strict mode), and strip_assets.
- New steps in both SWA workflows (same-repo PR and fork-preview) slotted
  between `mkdocs build` and the SWA deploy: collect → upload to blob →
  rewrite HTML refs to CDN URLs → strip binaries from the upload.
- On `main` only: inline orphan deletion guarded by min-file-count and
  max-delete-per-run checks against accidental wipeout.

This PR uploads to a per-PR prefix in the staging container; the preview
URL should load every binary from docs-cdn.chiligrafx.com.