### PR TITLE
Document supported image upload formats

### DIFF
--- a/docs/GraFx-Studio/guides/template-variables/image/index.md
+++ b/docs/GraFx-Studio/guides/template-variables/image/index.md
@@ -44,6 +44,9 @@ The path can be fixed: **Set Value** or fed through a (text / list) variable hav
 
 Choose "Allow Upload" and set a path, to allow end-users to upload assets.
 
+!!! note "Supported upload formats"
+    Uploads are limited to three file formats: **PNG**, **JPG** and **TIFF**. This is not configurable.
+
 For uploads, you can define a minimum width and height in pixels.
 
 Once enabled, each uploaded file is stored in the "Upload/" folder (for the GraFx Media connector), or in a custom path you specify.  


### PR DESCRIPTION
## What

Adds a note to the **Image variables** guide clarifying that end-user asset uploads are limited to three file formats: **PNG**, **JPG** and **TIFF**, and that this is not configurable.

Page: [GraFx-Studio/guides/template-variables/image](https://docs.chiligrafx.com/GraFx-Studio/guides/template-variables/image/)

## Why

The "Allow Upload" section explained how to enable uploads but did not state which formats are accepted. Users had no way to know the upload is restricted to PNG/JPG/TIFF or that the restriction can't currently be changed.

## Details

- Added a `!!! note "Supported upload formats"` admonition directly after the "Allow Upload" line, matching the existing admonition style used elsewhere on the page.

## Reviewer notes

- Please confirm the format list (PNG, JPG, TIFF) and the "not configurable" statement are accurate and current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)