### PR TITLE
[Docs] Note that HTML output does not support components

### DIFF
--- a/docs/GraFx-Studio/guides/output/html/index.md
+++ b/docs/GraFx-Studio/guides/output/html/index.md
@@ -5,6 +5,9 @@
 	
 	This feature and related endpoints (for the API) are not yet final: syntax might change, response could be different, etc. Don't base your production code on experimental features.
 
+!!! warning "Components are not supported"
+	HTML output does not support components. If your template uses components, it will fail during output.
+
 ## Create an output setting
 
 [How to create an export setting?](/GraFx-Studio/guides/output/settings/)


### PR DESCRIPTION
## What

Adds a warning to the [HTML output guide](https://docs.chiligrafx.com/GraFx-Studio/guides/output/html/) that HTML output does not support components. If a template uses components, it will fail during output.

The note is placed as its own `!!! warning` admonition directly below the existing "Experimental" note, so the hard limitation is visually distinct from the general experimental-feature caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)