### PR TITLE
[Docs] Add breaking change communication note to version guide

### DIFF
--- a/docs/CHILI-GraFx/guides/manage-environment-version/index.md
+++ b/docs/CHILI-GraFx/guides/manage-environment-version/index.md
@@ -60,6 +60,9 @@ Common patterns:
 - **Test or staging environments:** stay on Latest to catch issues with new releases before they affect production.
 - **Single-environment setups:** pin to a specific version and update on a schedule you control.
 
+!!! info "Staying ahead of changes"
+    We communicate upcoming changes in release notes, and in cases of potential breaking changes we will communicate via email ahead of time so you can prepare. In rare cases, an urgent fix — such as a security or SLA-related update — may ship with behavior changes on a shorter notice cycle. Pinning your production environment gives you full control over when those changes take effect.
+
 
 ## Compatibility rules
 

--- a/docs/CHILI-GraFx/guides/manage-environment-version/index.md
+++ b/docs/CHILI-GraFx/guides/manage-environment-version/index.md
@@ -52,7 +52,7 @@ To refresh GraFx Experience:
 
 ## When to pin vs. stay on Latest
 
-Pinning a version gives you control over when new Studio releases reach your environment. Without a deliberate versioning strategy, automatic updates can introduce behavior changes, break existing templates, or disrupt production workflows.
+Pinning a version gives you control over when new Studio releases reach your environment. A deliberate versioning strategy helps you adopt new features and prepare for potential behavior changes at your own pace, so updates don't catch existing templates or production workflows off guard.
 
 Common patterns:
 

--- a/docs/CHILI-GraFx/guides/manage-environment-version/index.md
+++ b/docs/CHILI-GraFx/guides/manage-environment-version/index.md
@@ -61,7 +61,7 @@ Common patterns:
 - **Single-environment setups:** pin to a specific version and update on a schedule you control.
 
 !!! info "Staying ahead of changes"
-    We communicate upcoming changes in release notes, and in cases of potential breaking changes we will communicate via email ahead of time so you can prepare. In rare cases, an urgent fix — such as a security or SLA-related update — may ship with behavior changes on a shorter notice cycle. Pinning your production environment gives you full control over when those changes take effect.
+    We communicate changes in release notes, and in cases of potential breaking changes we will communicate via email ahead of time so you can prepare. In rare cases, an urgent fix — such as a security or SLA-related update — may ship with behavior changes on a shorter notice cycle. Pinning your production environment gives you full control over when those changes take effect.
 
 
 ## Compatibility rules


### PR DESCRIPTION
## Summary
- Adds an info callout to the "When to pin vs. stay on Latest" section of the environment version guide
- Communicates that breaking changes are shared via release notes and email ahead of time, and that rare urgent fixes (security/SLA) may ship on shorter notice
- Reinforces version pinning as the way to stay in control
