### PR TITLE
Add unlisted resources section for support-shared docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,16 +13,6 @@
 
     ---
 
-    **Jul 8, 2026**: Upcoming Change: Superscript Font Features in GraFx Studio
-
-    ![rn_icon](/assets/icon-CHILI-GraFx.svg)
-
-    An upcoming GraFx Studio 1.46.0 fix makes superscript text follow the settings defined in the font. Templates using fonts with custom superscript features may render slightly differently.
-
-    [:octicons-arrow-right-24: Full Release Note](/release-notes/2026/07/08/upcoming-change-superscript-font-features-in-grafx-studio/)
-
-    ---
-
     **Jun 24, 2026**: CHILI GraFx Environment API: Exclude headers from connector proxy requests
 
     ![rn_icon](/assets/icon-CHILI-GraFx.svg)
@@ -70,6 +60,26 @@
     Version 1.4.0 of the Photoshop® exporter preserves clipping masks on export — built-in shapes (Rectangle, Ellipse, Polygon) and custom paths become Studio-native clipping masks, with stroke and corner properties intact.
 
     [:octicons-arrow-right-24: Full Release Note](/release-notes/2026/06/10/grafx-studio-adobe-photoshop-plugin-clipping-masks/)
+
+    ---
+
+    **Jun 10, 2026**: CHILI GraFx Environment API: Updated Swagger examples and faster responses
+
+    ![rn_icon](/assets/icon-CHILI-GraFx.svg)
+
+    The Swagger examples for the Media and Template GET endpoints have been refreshed to match what the API returns today, and frequently used operations respond faster thanks to more efficient cache communication.
+
+    [:octicons-arrow-right-24: Full Release Note](/release-notes/2026/06/10/chili-grafx-environment-api-updated-swagger-examples-and-faster-responses/)
+
+    ---
+
+    **Jun 9, 2026**: GraFx Media: TIFF images supported in print output
+
+    ![rn_icon](/assets/icon-GraFx-Media.svg)
+
+    TIFF images stored in GraFx Media now work in PDF output — served at full resolution with their original color space preserved, so a CMYK TIFF stays CMYK all the way to the final print-ready PDF.
+
+    [:octicons-arrow-right-24: Full Release Note](/release-notes/2026/06/09/grafx-media-tiff-images-supported-in-print-output/)
 
     ---
 

--- a/docs/resources/superscript-subscript-rendering.md
+++ b/docs/resources/superscript-subscript-rendering.md
@@ -1,8 +1,7 @@
 ---
-draft: false
-date: 2026-07-08T10:38:01
-categories:
-  - Operational updates
+search:
+  exclude: true
+noindex: true
 ---
 
 # Upcoming Change: Superscript and Subscript Rendering in GraFx Studio

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block extrahead %}
+  {{ super() }}
+  {% if page.meta and page.meta.noindex %}
+  <meta name="robots" content="noindex, nofollow">
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## What this does

Moves the superscript/subscript change note out of the release-notes blog and into a new, unlisted `docs/resources/` section, and adds a small theme override so pages in this bucket can opt out of search-engine indexing. The note is now served at `/resources/superscript-subscript-rendering/` — reachable by direct link, but absent from the navigation, the release-notes feed, category pages, RSS, the homepage, and on-site search.

Stacked on top of #756 (base is `REL-54/CHILI-GraFx/font-superscript-fix`).

## Why — three things

**1. Why move it to `resources/` at all.** This content is meant to be shared *reactively*, not broadcast. Our support team can hand the link to a customer who asks a question or runs into an issue with the superscript/subscript change — something we can drop into an email. It is deliberately **not** a company-wide, notify-every-customer announcement. Living in the release-notes blog would have surfaced it to everyone (feed, RSS, category pages, homepage card); moving it out makes it a targeted, send-when-needed resource.

**2. Why the name `resources`.** We wanted a generic bucket, not a one-off folder. `resources/` can hold change notes, updates, supplementary documentation, and anything else we may want to re-send in the future — content that is intentionally kept out of the site navigation but that we still want to be able to link someone to directly. A neutral name keeps the URL from advertising anything about the content or its visibility.

**3. The `overrides/main.html` template change and `noindex`.** MkDocs/Material has no built-in per-page "don't index" toggle, so this PR adds a tiny override that extends the theme's `extrahead` block and emits `<meta name="robots" content="noindex, nofollow">` on any page whose frontmatter sets `noindex: true`. The superscript note sets that flag (alongside `search: exclude: true` for on-site search). The point of `noindex` is simply that we don't want Google to index these pages and surface them in search results — so a prospect or new customer searching the web won't land on them.

## To be clear: this isn't about secrecy

We're not trying to hide anything. The content is plainly in this public GitHub repo, and the support team can freely send the link to whoever needs it. The goal is only that it shouldn't be **easily** accessible — we don't want it right in the face of a new customer or prospect, or for someone to land on it immediately (or at all) while browsing or searching. It's there when it's needed, but it's off to the side rather than front-and-center.

## Changes

- Move `docs/release-notes/releaseposts/2026070802.md` → `docs/resources/superscript-subscript-rendering.md`
- Strip the blog frontmatter; add `search: exclude: true` and `noindex: true`
- Add `overrides/main.html` — reusable `noindex` override driven by page frontmatter
- Revert the homepage feature card that had been added for this note

## Verification

Built the site locally: the `noindex, nofollow` meta tag renders on the resources page and does **not** appear on other pages (e.g. the homepage), confirming the frontmatter flag drives it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
