### PR TITLE
[CPAAS-2675] Improve docs on SAML FSSO claim names

### DIFF
--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -33,10 +33,10 @@ Next CHILI publish needs to configure a few things on the CHILI GraFx side, so y
 
 Please provide us with the following metadata:
 
-| **Name**                 | **Description**                                          |
-| ------------------------ | -------------------------------------------------------- |
-| Sign In URL              | `https://login.chiligrafx.com/login/callback`            |
-| X509 Signing Certificate | The name CHILI GraFx will identify itself as on your IDP |
+| **Name**                 | **Description**                                                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| Sign In URL              | The URL of your IDP CHILI GraFx should redirect to during sign in                                                                |
+| X509 Signing Certificate | The certificate used by your IDP to sign SAML responses. This is used by CHILI GraFx to verify the authenticity of the responses |
 
 Alternatively, you can provide the **SAML metadata URL**.  
 Above values can be derived from it.

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -16,7 +16,7 @@ CHILI publish recommends testing FSSO on a separate 'test' domain initially. Giv
 ## 2. Configure your IDP
 
 Create a SAML application in your IDP, using the gathered information.
-The **email address** should be used as the subject's `NameID` in SAML responses.
+The **email address** should be used as the "name identifier" in SAML responses.
 
 Please configure your IDP to provide at least following claims in SAML responses:
 

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -18,7 +18,7 @@ CHILI publish recommends testing FSSO on a separate 'test' domain initially. Giv
 Create a SAML application in your IDP, using the gathered information.
 The **email address** should be used as the subject's `NameID` in SAML responses.
 
-Please configure your IDP to provide at least the following claims in SAML responses:
+Please configure your IDP to provide us with the following claims in SAML responses:
 
 | **Claim name**                                                                    | **Required?** | **Description**                                                                                                                 |
 | --------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -9,7 +9,7 @@ Our Client Success team will provide you with the following details:
 | **Name**            | **Description**                                                                |
 | ------------------- | ------------------------------------------------------------------------------ |
 | Redirect URI        | `https://login.chiligrafx.com/login/callback`                                  |
-| Service Provider ID | The identifier (Entity ID) CHILI GraFx will use to identify itself to your IdP |
+| Service Provider ID | The identifier (Entity ID) CHILI GraFx will use to identify itself to your IDP |
 
 CHILI publish recommends testing FSSO on a separate 'test' domain initially. Given the variability in protocols and differences among various Identity Provider (IDP) services, there’s a risk of incompatible configurations. By enabling FSSO for the test domain first, you can verify the correctness of the configuration without impacting your users.
 

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -18,7 +18,7 @@ CHILI publish recommends testing FSSO on a separate 'test' domain initially. Giv
 Create a SAML application in your IDP, using the gathered information.
 The **email address** should be used as the subject's `NameID` in SAML responses.
 
-Please configure your IDP to provide us with the following claims in SAML responses (some are optional):
+Please configure your IDP to include at least the required claims below in SAML responses:
 
 | **Claim name**                                                                    | **Required?** | **Description**                                                                                                                 |
 | --------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -18,7 +18,7 @@ CHILI publish recommends testing FSSO on a separate 'test' domain initially. Giv
 Create a SAML application in your IDP, using the gathered information.
 The **email address** should be used as the subject's `NameID` in SAML responses.
 
-Please configure your IDP to provide us with the following claims in SAML responses:
+Please configure your IDP to provide us with the following claims in SAML responses (some are optional):
 
 | **Claim name**                                                                    | **Required?** | **Description**                                                                                                                 |
 | --------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -6,10 +6,10 @@ This document lists the steps required for setting up Federated Single Sign-On f
 
 Our Client Success team will provide you with the following details:
 
-| **Name**            | **Description**                                          |
-| ------------------- | -------------------------------------------------------- |
-| Redirect URI        | `https://login.chiligrafx.com/login/callback`            |
-| Service Provider ID | The name CHILI GraFx will identify itself as on your IDP |
+| **Name**            | **Description**                                                                |
+| ------------------- | ------------------------------------------------------------------------------ |
+| Redirect URI        | `https://login.chiligrafx.com/login/callback`                                  |
+| Service Provider ID | The identifier (Entity ID) CHILI GraFx will use to identify itself to your IdP |
 
 CHILI publish recommends testing FSSO on a separate 'test' domain initially. Given the variability in protocols and differences among various Identity Provider (IDP) services, there’s a risk of incompatible configurations. By enabling FSSO for the test domain first, you can verify the correctness of the configuration without impacting your users.
 
@@ -22,10 +22,10 @@ Please configure your IDP to include at least the required claims below in SAML 
 
 | **Claim name**                                                                    | **Requirement** | **Description**                                                                                                                 |
 | --------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `email` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   | Required      | The email address of the user                                                                                                   |
-| `given_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` | Required      | The given name of the user                                                                                                      |
-| `family_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`  | Required      | The family name of the user                                                                                                     |
-| `https://chili-publish.com/CGXGroups`                                             | Optional      | A list of UUIDs of the CHILI GraFx groups the user should be in. <br> This is only required if you use group-based permissions. |
+| `email` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   | Required        | The email address of the user                                                                                                   |
+| `given_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` | Required        | The given name of the user                                                                                                      |
+| `family_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`  | Required        | The family name of the user                                                                                                     |
+| `https://chili-publish.com/CGXGroups`                                             | Optional        | A list of UUIDs of the CHILI GraFx groups the user should be in. <br> This is only required if you use group-based permissions. |
 
 ## 3. CHILI GraFx Configuration
 
@@ -35,7 +35,7 @@ Please provide us with the following metadata:
 
 | **Name**                 | **Description**                                                                                                                  |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| Sign In URL              | The URL of your IDP that CHILI GraFx should redirect to during sign-in                                                          |
+| Sign In URL              | The URL of your IDP that CHILI GraFx should redirect to during sign-in                                                           |
 | X509 Signing Certificate | The certificate used by your IDP to sign SAML responses. This is used by CHILI GraFx to verify the authenticity of the responses |
 
 Alternatively, you can provide the **SAML metadata URL**.  

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -31,7 +31,7 @@ Please configure your IDP to provide us with the following claims in SAML respon
 
 Next CHILI publish needs to configure a few things on the CHILI GraFx side, so your users get redirected to your IDP when logging into CHILI GraFx.
 
-Please provide us with thefollowing metadata:
+Please provide us with the following metadata:
 
 | **Name**                 | **Description**                                          |
 | ------------------------ | -------------------------------------------------------- |

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -6,9 +6,9 @@ This document lists the steps required for setting up Federated Single Sign-On f
 
 Our Client Success team will provide you following details:
 
-| **Name**            | **Description**                                    |
-| ------------------- | -------------------------------------------------- |
-| Redirect URI        | `https://login.chiligrafx.com/login/callback`      |
+| **Name**            | **Description**                                          |
+| ------------------- | -------------------------------------------------------- |
+| Redirect URI        | `https://login.chiligrafx.com/login/callback`            |
 | Service Provider ID | The name CHILI GraFx will identify itself as on your IDP |
 
 CHILI publish recommends testing FSSO on a separate 'test' domain initially. Given the variability in protocols and differences among various Identity Provider (IDP) services, there’s a risk of incompatible configurations. By enabling FSSO for the test domain first, you can verify the correctness of the configuration without impacting your users.
@@ -18,14 +18,15 @@ CHILI publish recommends testing FSSO on a separate 'test' domain initially. Giv
 Create a SAML application in your IDP, using the gathered information.
 The **email address** should be used as the subject's `NameID` in SAML responses.
 
-Please configure your IDP to provide at least following required attributes in SAML responses:
+Please configure your IDP to provide at least following claims in SAML responses:
 
-| **Attribute name**                    | **Description**                                           |
-| ------------------------------------- | --------------------------------------------------------- |
-| `email`                               | The email address of the user                             |
-| `given_name`                          | The given name of the user                                |
-| `family_name`                         | The family name of the user                               |
-| `https://chili-publish.com/CGXGroups` | A list of UUIDs of the CHILI GraFx groups the user should be in |
+| **Claim name**                                                                    | **Required?** | **Description**                                                                                                                 |
+| --------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier`            | Required      | The unique identifier of the user                                                                                               |
+| `email` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   | Required      | The email address of the user                                                                                                   |
+| `given_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` | Required      | The given name of the user                                                                                                      |
+| `family_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`  | Required      | The family name of the user                                                                                                     |
+| `https://chili-publish.com/CGXGroups`                                             | Optional      | A list of UUIDs of the CHILI GraFx groups the user should be in. <br> This is only required if you use group-based permissions. |
 
 ## 3. CHILI GraFx Configuration
 
@@ -33,9 +34,9 @@ Next CHILI publish needs to configure a few things on the CHILI GraFx side, so y
 
 Please provide us following metadata:
 
-| **Name**                 | **Description**                                    |
-| ------------------------ | -------------------------------------------------- |
-| Sign In URL              | `https://login.chiligrafx.com/login/callback`      |
+| **Name**                 | **Description**                                          |
+| ------------------------ | -------------------------------------------------------- |
+| Sign In URL              | `https://login.chiligrafx.com/login/callback`            |
 | X509 Signing Certificate | The name CHILI GraFx will identify itself as on your IDP |
 
 Alternatively, you can provide the **SAML metadata URL**.  

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -35,7 +35,7 @@ Please provide us with the following metadata:
 
 | **Name**                 | **Description**                                                                                                                  |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| Sign In URL              | The URL of your IDP CHILI GraFx should redirect to during sign in                                                                |
+| Sign In URL              | The URL of your IDP that CHILI GraFx should redirect to during sign-in                                                          |
 | X509 Signing Certificate | The certificate used by your IDP to sign SAML responses. This is used by CHILI GraFx to verify the authenticity of the responses |
 
 Alternatively, you can provide the **SAML metadata URL**.  

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -29,9 +29,7 @@ Please configure your IDP to include at least the required claims below in SAML 
 
 ## 3. CHILI GraFx Configuration
 
-Next CHILI publish needs to configure a few things on the CHILI GraFx side, so your users get redirected to your IDP when logging into CHILI GraFx.
-
-Please provide us with the following metadata:
+Once you've created a SAML application in your IDP, provide us the following metadata so we can configure things to redirect users to your IDP when logging into CHILI GraFx:
 
 | **Name**                 | **Description**                                                                                                                  |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -36,7 +36,7 @@ Once you've created a SAML application in your IDP, provide us the following met
 | Sign In URL              | The URL of your IDP that CHILI GraFx should redirect to during sign-in                                                           |
 | X509 Signing Certificate | The certificate used by your IDP to sign SAML responses. This is used by CHILI GraFx to verify the authenticity of the responses |
 
-Alternatively, you can provide the **SAML metadata URL**, the above values can be derived from that.
+Alternatively, you can provide the **SAML metadata URL**. The above values can be derived from it.
 
 Please inform us of the **domain** you’d like to use for testing FSSO.
 

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -20,8 +20,8 @@ The **email address** should be used as the subject's `NameID` in SAML responses
 
 Please configure your IDP to include at least the required claims below in SAML responses:
 
-| **Claim name**                                                                    | **Required?** | **Description**                                                                                                                 |
-| --------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Claim name**                                                                    | **Requirement** | **Description**                                                                                                                 |
+| --------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `email` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   | Required      | The email address of the user                                                                                                   |
 | `given_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` | Required      | The given name of the user                                                                                                      |
 | `family_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`  | Required      | The family name of the user                                                                                                     |

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -20,12 +20,12 @@ The **email address** should be used as the subject's `NameID` in SAML responses
 
 Please configure your IDP to include at least the required claims below in SAML responses:
 
-| **Claim name**                                                                    | **Requirement** | **Description**                                                                                                                 |
-| --------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `email` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   | Required        | The email address of the user                                                                                                   |
-| `given_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` | Required        | The given name of the user                                                                                                      |
-| `family_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`  | Required        | The family name of the user                                                                                                     |
-| `https://chili-publish.com/CGXGroups`                                             | Optional        | A list of UUIDs of the CHILI GraFx groups the user should be in. <br> This is only required if you use group-based permissions. |
+| **Claim name**                                                                    | **Requirement** | **Description**                                                                                                                  |
+| --------------------------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `email` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   | Required        | The email address of the user                                                                                                    |
+| `given_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` | Required        | The given name of the user                                                                                                       |
+| `family_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`  | Required        | The family name of the user                                                                                                      |
+| `https://chili-publish.com/CGXGroups`                                             | Optional        | A list of UUIDs of the CHILI GraFx groups the user should be in. <br/> This is only required if you use group-based permissions. |
 
 ## 3. CHILI GraFx Configuration
 

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -4,7 +4,7 @@ This document lists the steps required for setting up Federated Single Sign-On f
 
 ## 1. Gather necessary info
 
-Our Client Success team will provide you with the following details:
+Contact our Client Success team via a support ticket to obtain the following details:
 
 | **Name**            | **Description**                                                                |
 | ------------------- | ------------------------------------------------------------------------------ |

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -20,8 +20,8 @@ The **email address** should be used as the subject's `NameID` in SAML responses
 
 Please configure your IDP to provide at least the following claims in SAML responses:
 
-| **Claim name** | **Required?** | **Description** |
-| -------------- | ------------- ||
+| **Claim name**                                                                    | **Required?** | **Description**                                                                                                                 |
+| --------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `email` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   | Required      | The email address of the user                                                                                                   |
 | `given_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` | Required      | The given name of the user                                                                                                      |
 | `family_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`  | Required      | The family name of the user                                                                                                     |

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -38,8 +38,7 @@ Please provide us with the following metadata:
 | Sign In URL              | The URL of your IDP that CHILI GraFx should redirect to during sign-in                                                           |
 | X509 Signing Certificate | The certificate used by your IDP to sign SAML responses. This is used by CHILI GraFx to verify the authenticity of the responses |
 
-Alternatively, you can provide the **SAML metadata URL**.  
-Above values can be derived from it.
+Alternatively, you can provide the **SAML metadata URL**, the above values can be derived from that.
 
 Please inform us of the **domain** you’d like to use for testing FSSO.
 

--- a/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
+++ b/docs/CHILI-GraFx/guides/setup-fsso/saml/index.md
@@ -4,7 +4,7 @@ This document lists the steps required for setting up Federated Single Sign-On f
 
 ## 1. Gather necessary info
 
-Our Client Success team will provide you following details:
+Our Client Success team will provide you with the following details:
 
 | **Name**            | **Description**                                          |
 | ------------------- | -------------------------------------------------------- |
@@ -16,13 +16,12 @@ CHILI publish recommends testing FSSO on a separate 'test' domain initially. Giv
 ## 2. Configure your IDP
 
 Create a SAML application in your IDP, using the gathered information.
-The **email address** should be used as the "name identifier" in SAML responses.
+The **email address** should be used as the subject's `NameID` in SAML responses.
 
-Please configure your IDP to provide at least following claims in SAML responses:
+Please configure your IDP to provide at least the following claims in SAML responses:
 
-| **Claim name**                                                                    | **Required?** | **Description**                                                                                                                 |
-| --------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier`            | Required      | The unique identifier of the user                                                                                               |
+| **Claim name** | **Required?** | **Description** |
+| -------------- | ------------- ||
 | `email` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`   | Required      | The email address of the user                                                                                                   |
 | `given_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` | Required      | The given name of the user                                                                                                      |
 | `family_name` or `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`  | Required      | The family name of the user                                                                                                     |
@@ -32,7 +31,7 @@ Please configure your IDP to provide at least following claims in SAML responses
 
 Next CHILI publish needs to configure a few things on the CHILI GraFx side, so your users get redirected to your IDP when logging into CHILI GraFx.
 
-Please provide us following metadata:
+Please provide us with thefollowing metadata:
 
 | **Name**                 | **Description**                                          |
 | ------------------------ | -------------------------------------------------------- |


### PR DESCRIPTION
* Add SAML standard claim names, as these can be used as well
* Auth0 maps these standard claim names to the right user attributes
* Make it clearer that the CGXGroups claim only is necessary if you want to federate group membership
* Fix the descriptions of the `Sign In URL` and `X509 Signing Certificate`. These were copied from `Redirect URI` and `Service Provider ID` and didn't make sense here.

Default mapping in Auth0 (Auth0 attribute name => SAML claim names it can get mapped from):

```
{
 "user_id": [
   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn",
   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
 ],
 "email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
 "name": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
 "given_name": [
   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
 ],
 "family_name": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
 "groups": "http://schemas.xmlsoap.org/claims/Group"
}
```