### PR TITLE
[Site] CDN sync: temporarily raise deletion safety-gate threshold

### DIFF
--- a/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-sky-012b9bc03.yml
@@ -138,8 +138,12 @@ jobs:
           echo "Sync plan: $upload_count upload(s), $delete_count deletion(s)"
           # Guard 2: a normal main build deletes ~0-5 files; a sudden spike
           # almost certainly indicates a bug in the build or the baseline.
-          if [ "$delete_count" -gt 10 ]; then
-            echo "::error::Refusing to sync: dry run would delete $delete_count blobs (>10). Aborting before any changes."
+          # Temporarily raised 10 -> 25 to let through the one-time cleanup
+          # from the GraFx Genie docs consolidation (#749), which orphaned 18
+          # legacy images now merged into the new GraFx-Genie section.
+          # TODO: revert to 10 after this lands and syncs successfully.
+          if [ "$delete_count" -gt 25 ]; then
+            echo "::error::Refusing to sync: dry run would delete $delete_count blobs (>25). Aborting before any changes."
             exit 1
           fi
 


### PR DESCRIPTION
- Bumped the >10 deletion guard to >25 in the main-branch CDN sync job, to let through the one-time cleanup of 18 legacy GraFx Genie images orphaned by the docs consolidation in #749.
- Revert this back to 10 once the next sync succeeds.