### PR TITLE
[Connectors][WRS-3099] Document multi-file connector compilation

### DIFF
--- a/docs/GraFx-Developers/connectors/connector-cli/index.md
+++ b/docs/GraFx-Developers/connectors/connector-cli/index.md
@@ -22,6 +22,37 @@ connector-cli -h
 
 This will give you an overview of the available commands
 
+## Project structure
+
+!!! note "Requires Connector CLI 1.13.0 or later"
+
+    Support for multiple `*.ts` files in a connector project was added in Connector CLI 1.13.0.
+
+Connector projects use `connector.ts` as the entry point and may include additional local `.ts` helper modules. The CLI bundles them into a single `out/connector.js`. See [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/) for the full layout.
+
+When the CLI builds your project, only these imports are allowed:
+
+1. **Relative / local project `.ts` files** — e.g. `./helpers`, `../utils/format`
+2. **`@chili-publish/studio-connectors`** — types and interfaces for the connector runtime
+
+Any other npm or third-party package is rejected at compile time.
+
+## Build a connector
+
+```bash
+connector-cli build
+```
+
+Compiles the project to `out/connector.js`. On a one-shot build, a compile failure exits with an error.
+
+### Watch mode
+
+```bash
+connector-cli build -w
+```
+
+Recompiles when any project `.ts` file changes. If a save introduces a compile error, the CLI logs the diagnostics and **keeps watching** — it does not exit.
+
 ## Debug a connector
 
 The `debug` command starts a local debug server with a browser-based debugger, where you can invoke your connector's methods and inspect what they return — without publishing anything to an environment first.
@@ -34,7 +65,7 @@ Open the reported URL in your browser, fill in the parameters for the method you
 
 ### Watch mode
 
-The debug application always runs in watch mode: the CLI recompiles `connector.ts` whenever you save it and reloads the browser tab, so your changes are immediately testable. There is no flag to turn this off.
+The debug application always runs in watch mode: the CLI recompiles whenever you save any project `.ts` file and reloads the browser tab, so your changes are immediately testable. There is no flag to turn this off. Compile errors are logged in the terminal; the previous successful build remains loaded until the next successful recompile.
 
 ### Execution metrics
 

--- a/docs/GraFx-Developers/connectors/connector-cli/project-structure/index.md
+++ b/docs/GraFx-Developers/connectors/connector-cli/project-structure/index.md
@@ -1,0 +1,17 @@
+# Connector project structure
+
+!!! note "Requires Connector CLI 1.13.0 or later"
+
+    Support for multiple `*.ts` files in a connector project was added in Connector CLI 1.13.0.
+
+## Layout
+
+| Path | Role |
+| ---- | ---- |
+| `connector.ts` | **Required** entry point. Export your connector class as `default`. |
+| Other local `.ts` files | Optional helpers, types, and utilities imported from `connector.ts` (or from each other). |
+| `package.json` | Connector metadata (`config`), dependencies, and scripts. |
+| `tsconfig.json` | TypeScript editor and typecheck settings for the connector project. |
+| `tests.json` | Optional test suite for media connectors (`connector-cli test`). |
+
+New projects from `connector-cli new` scaffold this layout. You can keep everything in `connector.ts`, or split helpers into local modules as the connector grows.

--- a/docs/GraFx-Developers/connectors/data-connector/build-a-simple-data-connector/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/build-a-simple-data-connector/index.md
@@ -71,7 +71,7 @@ Before we begin, you'll need to set up a Mockaroo account, create a schema, and 
         bun install
         ```
 
-4. Open `connector.ts` as this is the main connector file we will be modifying.
+4. Open `connector.ts` as this is the main connector file we will be modifying. (You can split helpers into other local `.ts` files later — see [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/).)
 
 ## Modifying the getPage Method
 

--- a/docs/GraFx-Developers/connectors/data-connector/data-connector-fundamentals/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/data-connector-fundamentals/index.md
@@ -15,7 +15,7 @@ Data connectors run in a limited isolated environment, which means they don't ha
 1. **Security**: JavaScript runs on the server, so it's crucial that it cannot directly access APIs that could compromise customer data.
 2. **Performance**: By limiting available APIs, scripts remain small and easier to optimize for performance.
 
-Due to this isolation, you cannot access the `window` object or many commonly used methods like `console.log`.
+Due to this isolation, you cannot access the `window` object or many commonly used methods like `console.log`. You also cannot import arbitrary npm packages — only local project `.ts` modules and `@chili-publish/studio-connectors` are allowed at build time. See [Connector CLI](/GraFx-Developers/connectors/connector-cli/).
 
 ## Runtime
 

--- a/docs/GraFx-Developers/connectors/data-connector/data-source-variable/build-a-data-source-variable-connector/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/data-source-variable/build-a-data-source-variable-connector/index.md
@@ -58,7 +58,7 @@ The property names must match the keys you return on each `DataItem` from `getPa
 
 Mockaroo's free API does not support cursor-based pagination. For this tutorial, fetch a larger batch once, keep it in memory for the request lifecycle, and use **opaque tokens** that encode a numeric offset.
 
-Add helpers at the top of your connector class, in the same file, or in a local `.ts` helper module (see [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/)):
+Add these helpers at the top of your `connector.ts` file, outside the connector class, or in a local `.ts` helper module (see [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/)):
 
 ```typescript
 const TOTAL_MOCK_RECORDS = 200;

--- a/docs/GraFx-Developers/connectors/data-connector/data-source-variable/build-a-data-source-variable-connector/index.md
+++ b/docs/GraFx-Developers/connectors/data-connector/data-source-variable/build-a-data-source-variable-connector/index.md
@@ -58,7 +58,7 @@ The property names must match the keys you return on each `DataItem` from `getPa
 
 Mockaroo's free API does not support cursor-based pagination. For this tutorial, fetch a larger batch once, keep it in memory for the request lifecycle, and use **opaque tokens** that encode a numeric offset.
 
-Add helpers at the top of your connector class (or in the same file):
+Add helpers at the top of your connector class, in the same file, or in a local `.ts` helper module (see [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/)):
 
 ```typescript
 const TOTAL_MOCK_RECORDS = 200;

--- a/docs/GraFx-Developers/connectors/media-connector/build-a-simple-media-connector/index.md
+++ b/docs/GraFx-Developers/connectors/media-connector/build-a-simple-media-connector/index.md
@@ -38,7 +38,7 @@ cd <projectName>
     bun install
     ```
 
-4. Open `connector.ts` as this is the main connector file we will be modifying.
+4. Open `connector.ts` as this is the main connector file we will be modifying. (You can split helpers into other local `.ts` files later — see [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/).)
 
 ## Modifying the Query Method
 

--- a/docs/GraFx-Developers/connectors/media-connector/media-connector-fundamentals/index.md
+++ b/docs/GraFx-Developers/connectors/media-connector/media-connector-fundamentals/index.md
@@ -15,7 +15,7 @@ Media connectors run in a limited isolated environment, which means they don't h
 1. **Security**: JavaScript runs on the server, so it's crucial that it cannot directly access APIs that could compromise customer data.
 2. **Performance**: By limiting available APIs, scripts remain small and easier to optimize for performance.
 
-Due to this isolation, you cannot access the `window` object or many commonly used methods like `console.log`.
+Due to this isolation, you cannot access the `window` object or many commonly used methods like `console.log`. You also cannot import arbitrary npm packages — only local project `.ts` modules and `@chili-publish/studio-connectors` are allowed at build time. See [Connector CLI](/GraFx-Developers/connectors/connector-cli/).
 
 ## Runtime
 

--- a/docs/release-notes/releaseposts/2026073101.md
+++ b/docs/release-notes/releaseposts/2026073101.md
@@ -1,0 +1,62 @@
+---
+draft: true
+date: 2099-01-01
+categories:
+  - Releases
+---
+
+# Connector CLI v1.13.0 — multi-file connector compilation
+
+![GraFx Studio icon](/assets/icon-GraFx-Studio.svg){.rn_icon}
+
+!!! note "Publish when the CLI release is on npm"
+
+    Keep this post as a draft until `@chili-publish/connector-cli` 1.13.0 is published. Frontmatter `date` is a placeholder required by the docs build — replace it with the real publish day, set `draft: false`, rename the file if needed to match that date, and link the exact release.
+
+A new version of the **Connector CLI** adds multi-file TypeScript compilation and expands watch coverage across the connector project.
+
+## ✨ New & Improved
+
+### Multi-file connector projects
+
+You can split connector logic across local `.ts` modules. The entry point remains `connector.ts`; the CLI bundles relative imports into a single `out/connector.js` for publish, test, and debug — the same contract as before.
+
+Allowed imports:
+
+- Relative / local project `.ts` files
+- `@chili-publish/studio-connectors`
+
+Any other npm package is rejected at compile time with an actionable error.
+
+See [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/) for the full layout.
+
+### Watch covers all project `.ts` files
+
+`connector-cli build -w` and `connector-cli debug` recompile when **any** project `.ts` file changes (not only `connector.ts`). Under `build -w`, a failed rebuild logs diagnostics and keeps watching instead of exiting.
+
+## ℹ️ Info for existing projects
+
+If you add helper `.ts` files to an older project that still has:
+
+```json
+"include": ["connector.ts"]
+```
+
+widen it so the editor sees the new modules, for example:
+
+```json
+{
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "out"]
+}
+```
+
+Also align `compilerOptions` with a project from `connector-cli new` (notably `moduleResolution: "Bundler"` and `noEmit: true`). If options differ or `tsconfig.json` is missing, the CLI uses built-in TypeScript settings; with `--verbose` it reports the skip reason. Fix your `tsconfig.json` to match the scaffold if you want to silence that verbose warning.
+
+New projects from `connector-cli new` already use the widened `include` and aligned `compilerOptions`.
+
+## More info
+
+- [Connector CLI](/GraFx-Developers/connectors/connector-cli/)
+- [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/)
+- Read more in the [Developer Center](/GraFx-Developers/overview/)

--- a/docs/release-notes/releaseposts/2026081201.md
+++ b/docs/release-notes/releaseposts/2026081201.md
@@ -1,6 +1,6 @@
 ---
-draft: true
-date: 2099-01-01
+draft: false
+date: 2026-08-12
 categories:
   - Releases
 ---
@@ -8,10 +8,6 @@ categories:
 # Connector CLI v1.13.0 — multi-file connector compilation
 
 ![GraFx Studio icon](/assets/icon-GraFx-Studio.svg){.rn_icon}
-
-!!! note "Publish when the CLI release is on npm"
-
-    Keep this post as a draft until `@chili-publish/connector-cli` 1.13.0 is published. Frontmatter `date` is a placeholder required by the docs build — replace it with the real publish day, set `draft: false`, rename the file if needed to match that date, and link the exact release.
 
 A new version of the **Connector CLI** adds multi-file TypeScript compilation and expands watch coverage across the connector project.
 
@@ -59,4 +55,5 @@ New projects from `connector-cli new` already use the widened `include` and alig
 
 - [Connector CLI](/GraFx-Developers/connectors/connector-cli/)
 - [Project structure](/GraFx-Developers/connectors/connector-cli/project-structure/)
+- [`@chili-publish/connector-cli` 1.13.0 on npm](https://www.npmjs.com/package/@chili-publish/connector-cli/v/1.13.0){target="_blank"}
 - Read more in the [Developer Center](/GraFx-Developers/overview/)

--- a/docs/release-notes/releaseposts/2026081201.md
+++ b/docs/release-notes/releaseposts/2026081201.md
@@ -47,7 +47,7 @@ widen it so the editor sees the new modules, for example:
 }
 ```
 
-Also align `compilerOptions` with a project from `connector-cli new` (notably `moduleResolution: "Bundler"` and `noEmit: true`). If options differ or `tsconfig.json` is missing, the CLI uses built-in TypeScript settings; with `--verbose` it reports the skip reason. Fix your `tsconfig.json` to match the scaffold if you want to silence that verbose warning.
+Aligning `compilerOptions` with a project from `connector-cli new` (notably `moduleResolution: "Bundler"` and `noEmit: true`) is **not required** for this release — existing projects keep working as they do today without that change. It is still worth doing so your editor/`tsc` setup matches what the CLI actually uses when it builds. If options differ or `tsconfig.json` is missing, the CLI falls back to built-in TypeScript settings; with `--verbose` it reports the skip reason. Matching the scaffold also silences that verbose warning.
 
 New projects from `connector-cli new` already use the widened `include` and aligned `compilerOptions`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,8 @@ plugins:
         Connectors:
           - GraFx-Developers/connectors/connectors-introduction/index.md: "What connectors are - pluggable media and data sources for Studio templates"
           - GraFx-Developers/connectors/pre-requisites/index.md: "Prerequisites for building a connector"
+          - GraFx-Developers/connectors/connector-cli/index.md: "Connector CLI - create, build, debug, test, and publish connectors"
+          - GraFx-Developers/connectors/connector-cli/project-structure/index.md: "Connector project layout - entry point, local TypeScript modules, and config files"
           - GraFx-Developers/connectors/authorization-for-connectors/index.md: "How connector authentication works - OAuth2, static tokens, and auth flows"
           - GraFx-Developers/connectors/media-connector/media-connector-introduction/index.md: "Media connectors let Studio browse and use assets from any DAM or storage system"
           - GraFx-Developers/connectors/media-connector/media-connector-fundamentals/index.md: "Core concepts for building a media connector"
@@ -664,7 +666,9 @@ nav:
             - 'References': 'GraFx-Developers/grafx-studio/references/index.md'
         - 'Connectors':
             - 'Introduction': 'GraFx-Developers/connectors/connectors-introduction/index.md'
-            - 'Connector CLI': 'GraFx-Developers/connectors/connector-cli/index.md'
+            - 'Connector CLI':
+                - 'Overview': 'GraFx-Developers/connectors/connector-cli/index.md'
+                - 'Project structure': 'GraFx-Developers/connectors/connector-cli/project-structure/index.md'
             - 'Media Connectors':
                 - 'Introduction': 'GraFx-Developers/connectors/media-connector/media-connector-introduction/index.md'
                 - 'Media Connector Fundamentals': 'GraFx-Developers/connectors/media-connector/media-connector-fundamentals/index.md'


### PR DESCRIPTION
Documents Connector CLI multi-file TypeScript compilation (WRS-3099).

- Add Connector CLI project-structure page and nav/LLM entries in `mkdocs.yml`
- Update Connector CLI overview (build/watch, allowed imports)
- Cross-link media and data connector guides
- Add draft release note for CLI v1.13.0 (kept as draft until npm publish)

## Related tickets

- [WRS-3099](https://chilipublishintranet.atlassian.net/browse/WRS-3099)

[WRS-3099]: https://chilipublishintranet.atlassian.net/browse/WRS-3099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ